### PR TITLE
Guide menu changes

### DIFF
--- a/assets/stylesheets/overrides.style.css
+++ b/assets/stylesheets/overrides.style.css
@@ -22,11 +22,22 @@ dd img {
 
 #guides {
   background-color: #2A8008;
-  color: #5FBB58;
+  color: #3C9936;
 }
 
 #guides hr {
   background-color: #5FBB58;
+}
+
+#guides dl dt {
+  color: #5FBB58;
+  letter-spacing: 0.05em;
+  font-weight: bold;
+}
+
+#guides dl dd {
+  text-indent: -10px;
+  margin-left: 18px;
 }
 
 #mainCol a, #subCol a, #feature a, a, a:link, a:visited {

--- a/guides.yml
+++ b/guides.yml
@@ -107,7 +107,7 @@ index:
       url: themeable_controls
       text: "In this guide, we'll go over to how to develop a control that can be themed. This can be useful if you want to have different visual displays in your application (like a regular and overlay theme) or when distributing a theme for wider use."
       construction: true
-    - title: "Using Chance, SproutCore's CSS framework"
+    - title: "Using Chance, SproutCore's CSS Framework"
       url: chance
       text: "Chance is SproutCore's CSS preprocessor. In this guide, you will learn how to use the CSS extensions that come with Chance to streamline your styling workflow."
       construction: true


### PR DESCRIPTION
Cleaned up the guides menu to be a bit easier to read. Capitalized the word "Framework" since all other guides follow this convention.
