### PR TITLE
Fixes a rendering issue for Firefox, still looks good in others.

### DIFF
--- a/assets/stylesheets/overrides.style.css
+++ b/assets/stylesheets/overrides.style.css
@@ -64,3 +64,10 @@ dd img {
 div.filename {
   padding-top: 5px;
 }
+
+ol.chapters li a p {
+  /*
+   * FIXES: Firefox incorrectly renders block elements inside of list items
+   */
+  display: inline;
+}


### PR DESCRIPTION
The table of contents was displaying incorrectly in Firefox and it looked pretty horrible. Changed the &lt;p&gt; tag to be "display: inline" instead of the default of "display: block" so it would render properly.
