### PR TITLE
Removed underline from table of contents.

### DIFF
--- a/assets/stylesheets/overrides.style.css
+++ b/assets/stylesheets/overrides.style.css
@@ -64,3 +64,7 @@ dd img {
 div.filename {
   padding-top: 5px;
 }
+
+ol.chapters a {
+  text-decoration: none;
+}


### PR DESCRIPTION
The underline on the table of contents links looked kinda messy. The current version of the guides is set to "text-decoration: none". I think this looks much cleaner, so I added it back in (not sure when it changed).
