### PR TITLE
Code block file reference fix

### DIFF
--- a/source/html_based.textile
+++ b/source/html_based.textile
@@ -243,7 +243,7 @@ In our todos app, we want to display completed todos in a different visual style
 
 We'll use a property on the collection helper to set up this binding:
 
-<javascript filename="in apps/todos/todos.js">
+<javascript filename="in apps/todos/resources/templates/todos.handlebars">
 <!-- replacing the previous code -->
 
 {{#collection Todos.TodoListView itemClassBinding="content.isDone"}}


### PR DESCRIPTION
Minor fix where code block was being pointed as updating code in todo.js when really it was a template related change.
