### PR TITLE
I guess that it should be a TemplateView instead of a View.

### DIFF
--- a/source/using_handlebars.textile
+++ b/source/using_handlebars.textile
@@ -433,7 +433,7 @@ h3. Displaying a List of Items
 If you need to display a basic list of items, use Handlebar's +{{each}}+ helper:
 
 <javascript>
-MyApp.PeopleView = SC.View.extend({
+MyApp.PeopleView = SC.TemplateView.extend({
   people: [ SC.Object.create({ name: 'Steph'}),
             SC.Object.create({ name: 'Tom' }) ]
 });


### PR DESCRIPTION
As the guide is dealing with Handlebars templates, referring to SC.View looks like a typo.
