### PR TITLE
V2.0: fix link to css file

### DIFF
--- a/source/getting_started.textile
+++ b/source/getting_started.textile
@@ -92,7 +92,7 @@ NOTE: <code>SC.ArrayProxy</code> acts as a proxy onto its +content+ Array. Sprou
 
 h3. Doing It with Style
 
-We've provided a simple stylesheet to give the application some style.  Download the "CSS file":https://github.com/sproutcore/Todos-Example/raw/master/apps/todos/resources/stylesheets/todos.css, add it to your project's +css+ directory, then include it in your +index.html+ +<head>+ tag:
+We've provided a simple stylesheet to give the application some style.  Download the "CSS file":https://github.com/sproutcore/todos/raw/master/apps/todos/resources/stylesheets/todos.css, add it to your project's +css+ directory, then include it in your +index.html+ +<head>+ tag:
 
 <html filename="index.html">
 <link rel="stylesheet" href="css/todos.css">


### PR DESCRIPTION
The link was pointing to the former css file wich is not working with the current v2.0 todo code.
