### PR TITLE
Beta 3.0 parentView removal in Todo example code

### DIFF
--- a/source/getting_started.textile
+++ b/source/getting_started.textile
@@ -187,8 +187,8 @@ The first thing we need to do is add a checkbox to each todo list item. As was m
 {{view Todos.CreateTodoView id="new-todo" placeholder="What needs to be done?"}}
 
 {{#collection contentBinding="Todos.todosController" tagName="ul"}}
-{{view SC.Checkbox titleBinding="parentView.content.title"
-    valueBinding="parentView.content.isDone"}}
+{{view SC.Checkbox titleBinding="content.title"
+    valueBinding="content.isDone"}}
 {{/collection}}
 </script>
 </html>


### PR DESCRIPTION
With the currently Beta 3.0 removal of parentView, I was going through
the Getting started guide, brand new to Sproutcore and pretty new to JS,
I ran into the error of not being able to apply the isDone css, and ran
across in the blog Beta 3.0 parentView is no longer needed in this context. I
removed it from these two lines. First time committing to a project so I
hope this is the correct way to do things.
