### PR TITLE
Fix typo in link to writing unit tests page

### DIFF
--- a/source/unit_test_framework.textile
+++ b/source/unit_test_framework.textile
@@ -45,7 +45,7 @@ test("value of 'string' is 'Hello World', function() {
 });
 </javascript>
 
-See "Writing a Unit Test Case":/writing_unit_test.html for more information on this process.
+See "Writing a Unit Test Case":/writing_unit_tests.html for more information on this process.
 
 h4. Running Unit Test Cases
 


### PR DESCRIPTION
Hello,

The link 'Writing a Unit Test Case' on http://guides.sproutcore.com/unit_test_framework.html has a typo.

The link should be writing_unit_tests.html instead of writing_unit_test.html.
It is broken as-is.

-Matt
