### PR TITLE
You shouldn't bind to the `content` property of an array controller

### DIFF
--- a/source/views.textile
+++ b/source/views.textile
@@ -162,7 +162,7 @@ Now we can bind our source list to the +SC.ArrayController+ to get a dynamic lis
 <javascript filename="in apps/addressbook/resources/main_page.js">
 topLeftView: SC.SourceListView.design({
   contentValueKey: 'name',
-  contentBinding: 'AddressBook.contactsController.content',
+  contentBinding: 'AddressBook.contactsController.arrangedObjects',
   selectionBinding: 'AddressBook.contactsController.selection'
 })
 </javascript>


### PR DESCRIPTION
Instead, it should be the `arrangedObjects` property. This allows for sorting, and also stops direct access to the content, which is the point of a controller.
