### PR TITLE
Move the guides to the NodeJS build tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1150 @@
+{
+  "name": "sproutcore-guides",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@bevry/pluginloader": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@bevry/pluginloader/-/pluginloader-1.1.2.tgz",
+      "integrity": "sha512-EgSMNx7HyalYXzuk+ciPKBv+OhgwJWnSjbDnDaxybjuysCKlLTMTLhHrR7pCDyakXHYi7XCq57SDxMpdo3WGAQ==",
+      "requires": {
+        "editions": "^2.0.2",
+        "errlop": "^1.0.3",
+        "semver": "^5.5.1",
+        "typechecker": "^4.6.0"
+      }
+    },
+    "@types/minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
+    },
+    "ambi": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ambi/-/ambi-3.2.0.tgz",
+      "integrity": "sha512-nj5sHLPFd7u2OLmHdFs4DHt3gK6edpNw35hTRIKyI/Vd2Th5e4io50rw1lhmCdUNO2Mm4/4FkHmv6shEANAWcw==",
+      "requires": {
+        "editions": "^2.1.0",
+        "typechecker": "^4.3.0"
+      }
+    },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
+    },
+    "ansistyles": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "backbone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
+      "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
+      "requires": {
+        "underscore": ">=1.8.3"
+      }
+    },
+    "bal-util": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/bal-util/-/bal-util-2.8.0.tgz",
+      "integrity": "sha512-4krTXfpVnB1IOVBHqu8S86GrWJOd7hRts/nruO/GrhlPrVYwyOW8tHSjY2TbytZ4oVoKJXU8chaW+C0bnBiwjw==",
+      "requires": {
+        "ambi": "^2.5.0",
+        "eachr": "^3.2.0",
+        "editions": "^1.3.4",
+        "extendr": "^3.2.2",
+        "extract-opts": "^3.3.1",
+        "ignorefs": "^1.1.1",
+        "safefs": "^4.1.0",
+        "scandirectory": "^2.5.0",
+        "taskgroup": "^5.0.1",
+        "typechecker": "^4.3.0"
+      },
+      "dependencies": {
+        "ambi": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.5.0.tgz",
+          "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
+          "requires": {
+            "editions": "^1.1.1",
+            "typechecker": "^4.3.0"
+          }
+        },
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        },
+        "scandirectory": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/scandirectory/-/scandirectory-2.5.0.tgz",
+          "integrity": "sha1-bOA/VKCQtmjjy+2/IO354xBZPnI=",
+          "requires": {
+            "ignorefs": "^1.0.0",
+            "safefs": "^3.1.2",
+            "taskgroup": "^4.0.5"
+          },
+          "dependencies": {
+            "safefs": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/safefs/-/safefs-3.2.2.tgz",
+              "integrity": "sha1-gXDBRE1wOOCMrqBaN0+uL6NJ4Vw=",
+              "requires": {
+                "graceful-fs": "*"
+              }
+            },
+            "taskgroup": {
+              "version": "4.3.1",
+              "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-4.3.1.tgz",
+              "integrity": "sha1-feGT/r12gnPEV3MElwJNUSwnkVo=",
+              "requires": {
+                "ambi": "^2.2.0",
+                "csextends": "^1.0.3"
+              }
+            }
+          }
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "binaryextensions": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.2.tgz",
+      "integrity": "sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "cac": {
+      "version": "5.0.16",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-5.0.16.tgz",
+      "integrity": "sha512-QHPtQCPvzqtTkcdrRAcylHJWa48zvBdQVDdutMgIL70CHiyQ6WmKh9ZYJZXSk3lq6sE2K7y92xItXFO1Bk892A==",
+      "requires": {
+        "chalk": "^2.4.1",
+        "joycon": "^2.1.2",
+        "minimost": "^1.2.0",
+        "redent": "^2.0.0",
+        "string-width": "^2.1.1",
+        "text-table": "^0.2.0"
+      }
+    },
+    "caterpillar": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/caterpillar/-/caterpillar-3.2.0.tgz",
+      "integrity": "sha512-OXbi2kJkNBRnrq7rG1AL3zXAUlWcuwP/lwGkW6ZIAHfW3jpZCzWp2s69paw08k9QM+PuA+qcyiqAiSTZNLO+ag==",
+      "requires": {
+        "editions": "^2.1.3",
+        "extendr": "^3.2.0",
+        "rfc-log-levels": "^1.0.0"
+      }
+    },
+    "caterpillar-filter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/caterpillar-filter/-/caterpillar-filter-3.1.0.tgz",
+      "integrity": "sha512-a1IPgk2MMVxrCYihwLlR6zbjiLHX7UqxzlNPw69Rj6ak6CivdliWGlhwg0mgbu6J+gYmnKmJYbqnLzA2Ze67+Q==",
+      "requires": {
+        "editions": "^2.1.3"
+      }
+    },
+    "caterpillar-human": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/caterpillar-human/-/caterpillar-human-3.0.0.tgz",
+      "integrity": "sha1-PcytsXL7fuifjSo1skdc0/FaFXo=",
+      "requires": {
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "editions": "^1.1.1"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        }
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "core-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
+      "integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g=="
+    },
+    "csextends": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/csextends/-/csextends-1.2.0.tgz",
+      "integrity": "sha512-S/8k1bDTJIwuGgQYmsRoE+8P+ohV32WhQ0l4zqrc0XDdxOhjQQD7/wTZwCzoZX53jSX3V/qwjT+OkPTxWQcmjg=="
+    },
+    "cson": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cson/-/cson-5.1.0.tgz",
+      "integrity": "sha512-hh97pBcNEc24OQn+CBYu1pp9kcEqp3dE0oO52QIoQkDREnZYHUD1YcKcGvHU+k9lgCmIXHslJfGTie58zjhLnA==",
+      "requires": {
+        "coffee-script": "^1.12.7",
+        "cson-parser": "^1.3.4",
+        "editions": "^1.3.3",
+        "extract-opts": "^3.3.1",
+        "requirefresh": "^2.1.0",
+        "safefs": "^4.1.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        }
+      }
+    },
+    "cson-parser": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
+      "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
+      "requires": {
+        "coffee-script": "^1.10.0"
+      }
+    },
+    "docmatter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/docmatter/-/docmatter-1.1.0.tgz",
+      "integrity": "sha512-PBOqhyguhFzaBYgVz2auXJgr2a+zy/qsk67gTm/5z1G1zZGg3/m7vqPKW3ZEBMb+ednYrq8vtoOzMCeslPVC3w==",
+      "requires": {
+        "editions": "^2.1.3"
+      }
+    },
+    "docpad": {
+      "version": "6.82.5",
+      "resolved": "https://registry.npmjs.org/docpad/-/docpad-6.82.5.tgz",
+      "integrity": "sha512-U5M7ivGrOq1mjut9hCMVjk09qoYCrKbXNxdyLmGbpNGRu4k/5O9ywMNh+CxSIU3Di2s43s5zke9w2yoPcii+5w==",
+      "requires": {
+        "@bevry/pluginloader": "^1.1.1",
+        "ambi": "^3.1.1",
+        "ansistyles": "^0.1.3",
+        "backbone": "1.3.3",
+        "bal-util": "~2.8.0",
+        "cac": "^5.0.11",
+        "caterpillar": "^3.1.2",
+        "caterpillar-filter": "^3.0.0",
+        "caterpillar-human": "^3.0.0",
+        "core-js": "^2.5.7",
+        "cson": "^5.1.0",
+        "docmatter": "^1.0.0",
+        "docpad-baseplugin": "^1.0.3",
+        "eachr": "^3.2.0",
+        "editions": "^2.0.2",
+        "encoding": "~0.1.12",
+        "envfile": "^2.3.0",
+        "errlop": "^1.0.3",
+        "event-emitter-grouped": "^2.7.1",
+        "extendr": "^3.3.0",
+        "extract-opts": "^3.3.1",
+        "ignorefs": "^1.2.0",
+        "inquirer": "^6.2.0",
+        "istextorbinary": "^2.2.1",
+        "jschardet": "~1.6.0",
+        "lazy-require": "^2.2.0",
+        "mime": "^2.3.1",
+        "node-fetch": "^2.2.0",
+        "progress-title": "^1.1.0",
+        "query-engine": "~1.5.7",
+        "rfc-log-levels": "^1.1.0",
+        "rimraf": "^2.6.2",
+        "safefs": "^4.1.0",
+        "safeps": "^7.0.1",
+        "scandirectory": "^3.0.1",
+        "semver": "^5.5.1",
+        "taskgroup": "^5.3.0",
+        "typechecker": "^4.6.0",
+        "unbounded": "^1.1.0",
+        "underscore": "^1.9.1",
+        "watchr": "^4.0.1",
+        "yamljs": "~0.3.0"
+      }
+    },
+    "docpad-baseplugin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/docpad-baseplugin/-/docpad-baseplugin-1.0.3.tgz",
+      "integrity": "sha512-CsUeQCvIuEfMBhlwea83G9QhLRpQaxWk7pLljUl4yFOsvIWB0J0YbjFXuEmCCC5FUZcAdBwtQJSIR8MKYZVtZg==",
+      "requires": {
+        "eachr": "^3.2.0",
+        "editions": "^2.0.2",
+        "errlop": "^1.0.3",
+        "extendr": "^3.3.0",
+        "typechecker": "^4.5.0"
+      }
+    },
+    "docpad-plugin-eco": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/docpad-plugin-eco/-/docpad-plugin-eco-2.3.0.tgz",
+      "integrity": "sha512-+5hhcnYLNX3zOeDu7ulE4AT89wJ8s7eOYP1WuDD52ioJJLTbi0g97B3Ho8t0O/qHeQdIveea+Hf91kVUZtCN+A==",
+      "requires": {
+        "eco": "~1.1.0-rc-3",
+        "editions": "^1.3.4"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        }
+      }
+    },
+    "docpad-plugin-highlightjs": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/docpad-plugin-highlightjs/-/docpad-plugin-highlightjs-2.6.0.tgz",
+      "integrity": "sha512-3cqE5X8/Hkl/gW1Y1aomZOiSQ0qzLgEvEB49pHb1fue5SVp5YY1QaWJnKExP3p9z3y8NBGe/6NGJoO8jQ/qG9A==",
+      "requires": {
+        "bal-util": "~2.7.0",
+        "editions": "^1.3.4",
+        "extendr": "^3.3.0",
+        "he": "^1.1.1",
+        "highlight.js": "^9.6.0"
+      },
+      "dependencies": {
+        "ambi": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.5.0.tgz",
+          "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
+          "requires": {
+            "editions": "^1.1.1",
+            "typechecker": "^4.3.0"
+          }
+        },
+        "bal-util": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/bal-util/-/bal-util-2.7.0.tgz",
+          "integrity": "sha512-BZQ1x0B6qVwaboMURblOtKRJoZLUSWPGsYH7Ck6f6afd2QPkXRe74ztoCyfwExakF4qVCIiv1XgzlnCKGq6V5w==",
+          "requires": {
+            "ambi": "^2.5.0",
+            "eachr": "^3.2.0",
+            "editions": "^1.3.4",
+            "extendr": "^3.2.2",
+            "extract-opts": "^3.3.1",
+            "ignorefs": "^1.1.1",
+            "safefs": "^4.1.0",
+            "scandirectory": "^2.5.0",
+            "taskgroup": "^5.0.1",
+            "typechecker": "^4.3.0"
+          }
+        },
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        },
+        "scandirectory": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/scandirectory/-/scandirectory-2.5.0.tgz",
+          "integrity": "sha1-bOA/VKCQtmjjy+2/IO354xBZPnI=",
+          "requires": {
+            "ignorefs": "^1.0.0",
+            "safefs": "^3.1.2",
+            "taskgroup": "^4.0.5"
+          },
+          "dependencies": {
+            "safefs": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/safefs/-/safefs-3.2.2.tgz",
+              "integrity": "sha1-gXDBRE1wOOCMrqBaN0+uL6NJ4Vw=",
+              "requires": {
+                "graceful-fs": "*"
+              }
+            },
+            "taskgroup": {
+              "version": "4.3.1",
+              "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-4.3.1.tgz",
+              "integrity": "sha1-feGT/r12gnPEV3MElwJNUSwnkVo=",
+              "requires": {
+                "ambi": "^2.2.0",
+                "csextends": "^1.0.3"
+              }
+            }
+          }
+        }
+      }
+    },
+    "docpad-plugin-marked": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/docpad-plugin-marked/-/docpad-plugin-marked-2.5.0.tgz",
+      "integrity": "sha512-NmhB/XkVU28CmQYgCyeVhQcgVXx8GWrl2Sj1ZKZFTC8XZCO2BeZtqTU6LPaknJeKc3nAkt/viht3K6P6RONC3g==",
+      "requires": {
+        "editions": "^1.3.4",
+        "marked": "~0.4.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        }
+      }
+    },
+    "eachr": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
+      "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
+      "requires": {
+        "editions": "^1.1.1",
+        "typechecker": "^4.3.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        }
+      }
+    },
+    "eco": {
+      "version": "1.1.0-rc-3",
+      "resolved": "https://registry.npmjs.org/eco/-/eco-1.1.0-rc-3.tgz",
+      "integrity": "sha1-dCoyxGFa9wWrPppGts5cFtvFcmI=",
+      "requires": {
+        "coffee-script": ">=1.2.0",
+        "strscan": ">=1.0.1"
+      }
+    },
+    "editions": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
+      "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
+      "requires": {
+        "errlop": "^1.1.1",
+        "semver": "^5.6.0"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "envfile": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/envfile/-/envfile-2.3.0.tgz",
+      "integrity": "sha512-xcwno0xGhSVhgBfFx9SxwYd6FNfTdq8SMFjrQ4FYsxYUNQMPJTXn7dERrX439F1V4Ukk9x/nL/5GcNZaIVUT7g==",
+      "requires": {
+        "ambi": "^2.4.0",
+        "eachr": "^3.1.0",
+        "editions": "^1.3.3",
+        "typechecker": "^4.0.1"
+      },
+      "dependencies": {
+        "ambi": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.5.0.tgz",
+          "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
+          "requires": {
+            "editions": "^1.1.1",
+            "typechecker": "^4.3.0"
+          }
+        },
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        }
+      }
+    },
+    "errlop": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.1.1.tgz",
+      "integrity": "sha512-WX7QjiPHhsny7/PQvrhS5VMizXXKoKCS3udaBp8gjlARdbn+XmK300eKBAAN0hGyRaTCtRpOaxK+xFVPUJ3zkw==",
+      "requires": {
+        "editions": "^2.1.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "event-emitter-grouped": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/event-emitter-grouped/-/event-emitter-grouped-2.7.1.tgz",
+      "integrity": "sha512-SKeWdzwPRyUTkc6ixmnTwLXqYX4LdpKSNliqm95NxUxzwsT+Bu+eEmgalRajPY5SHcbOG/9UHHao8+p5BI3uQA==",
+      "requires": {
+        "editions": "^2.0.2",
+        "taskgroup": "^5.0.0",
+        "unbounded": "^1.1.0"
+      }
+    },
+    "extendr": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/extendr/-/extendr-3.4.1.tgz",
+      "integrity": "sha512-xcdwhNFctt6U7XVBYgB35YG/CZFOZUZw+OCNiMPsgbENLlajgrZLVV6bgS/9zLHnY7s5nW6nJZcNrBvq033l1w==",
+      "requires": {
+        "editions": "^2.1.0",
+        "typechecker": "^4.7.0"
+      }
+    },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "extract-opts": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz",
+      "integrity": "sha1-WrvtyYwNUgLjJ4cn+Rktfghsa+E=",
+      "requires": {
+        "eachr": "^3.2.0",
+        "editions": "^1.1.1",
+        "typechecker": "^4.3.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        }
+      }
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "highlight.js": {
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A=="
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignorefs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ignorefs/-/ignorefs-1.2.0.tgz",
+      "integrity": "sha1-2ln7hYl25KXkNwLM0fKC/byeV1Y=",
+      "requires": {
+        "editions": "^1.3.3",
+        "ignorepatterns": "^1.1.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        }
+      }
+    },
+    "ignorepatterns": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ignorepatterns/-/ignorepatterns-1.1.0.tgz",
+      "integrity": "sha1-rI9DbyI5td+2bV8NOpBKh6xnzF4="
+    },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "inquirer": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+      "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.10",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.1.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
+    "istextorbinary": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.3.0.tgz",
+      "integrity": "sha512-xs+IFjzw1/5n45nMYUh2ipLWGarmE0bDVR85WAiYUXzawc8NYn1WW0qaq2rSEFIR3NoNkaAvOr3FVMojFz5uUg==",
+      "requires": {
+        "binaryextensions": "^2.1.2",
+        "editions": "^2.0.2",
+        "textextensions": "^2.4.0"
+      }
+    },
+    "joycon": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.3.tgz",
+      "integrity": "sha512-4gHuFIQJPickKKT4sQ0B3IyQJ1uwIATwMPXWXiq/+NAUWSzhRotwV3bNocahOsqpzI6cTZErLtCvKzZFthZ6eQ=="
+    },
+    "jschardet": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
+    },
+    "lazy-require": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lazy-require/-/lazy-require-2.2.0.tgz",
+      "integrity": "sha1-Iv9A5dHpPkda7E3/aTaX/PewsW0=",
+      "requires": {
+        "editions": "^1.1.1",
+        "extract-opts": "^3.3.1",
+        "safeps": "^6.0.2"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        },
+        "safeps": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/safeps/-/safeps-6.4.0.tgz",
+          "integrity": "sha1-s2Kxfd5GVS9xtn1nW1GQKHz3tjw=",
+          "requires": {
+            "editions": "^1.3.3",
+            "extract-opts": "^3.3.1",
+            "safefs": "^4.1.0",
+            "taskgroup": "^5.0.0",
+            "typechecker": "^4.3.0"
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "marked": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
+    },
+    "mime": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "minimost": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimost/-/minimost-1.2.0.tgz",
+      "integrity": "sha512-/+eWyOtXw41WIUV9rBgrXna11bxbqymebSeW2arsfp/MCGCwe+2czzsOueEtLZgH4xb4QXhje5H9MLCsCPibLA==",
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "minimist": "^1.2.0"
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "progress-title": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/progress-title/-/progress-title-1.2.0.tgz",
+      "integrity": "sha512-6IBum7PUrYYR16vMediDlo66Qtj5s4OAdIJ9qC8ydyia2tRB+XceS9Y/X5DvcrVKUtJGH6sH8hj9df3yOk/9vg==",
+      "requires": {
+        "editions": "^2.1.3"
+      }
+    },
+    "query-engine": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/query-engine/-/query-engine-1.5.7.tgz",
+      "integrity": "sha1-AepGbRPBxXA0OxfXAGy6bhw6ars="
+    },
+    "readdir-cluster": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/readdir-cluster/-/readdir-cluster-1.1.0.tgz",
+      "integrity": "sha1-sNOxpzPBE0V7ThrYmR/fgagXSnc=",
+      "requires": {
+        "editions": "^1.1.1"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        }
+      }
+    },
+    "redent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+      "requires": {
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
+      }
+    },
+    "requirefresh": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-2.2.0.tgz",
+      "integrity": "sha512-gXQWrZkXNZZ6qVEh6PQvoASxLY3r6AR4jH8fFjZ+BfPJpDV6RTI82J4A3tkAn2wikU7rxfzU3sIPj94zEV6xPA==",
+      "requires": {
+        "editions": "^2.1.3"
+      }
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rfc-log-levels": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rfc-log-levels/-/rfc-log-levels-1.1.0.tgz",
+      "integrity": "sha512-GFN9gTsQxHSs4PitqsnYO036weay+K7f2gQ3yj5KilKkeZhEDugAKvak1AyMfdae/LlgjcgZjPxL0inPEXueRA=="
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safefs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
+      "integrity": "sha1-+CrrS9165R9lPrIPZyizBYyNZEU=",
+      "requires": {
+        "editions": "^1.1.1",
+        "graceful-fs": "^4.1.4"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        }
+      }
+    },
+    "safeps": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/safeps/-/safeps-7.0.1.tgz",
+      "integrity": "sha1-FXPMsJy/AeAckFIr68bIsicL8hk=",
+      "requires": {
+        "editions": "^1.3.3",
+        "extract-opts": "^3.3.1",
+        "safefs": "^4.1.0",
+        "taskgroup": "^5.0.0",
+        "typechecker": "^4.3.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        }
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "scandirectory": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scandirectory/-/scandirectory-3.0.1.tgz",
+      "integrity": "sha1-Jd0gFCfDPM5Pj0Cy838tA9B4V7o=",
+      "requires": {
+        "editions": "^1.3.1",
+        "ignorefs": "^1.1.1",
+        "readdir-cluster": "^1.1.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        }
+      }
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+    },
+    "strscan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strscan/-/strscan-1.0.1.tgz",
+      "integrity": "sha1-Ry2bwAxo6QbvL8Is33Yr58YazE0="
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "taskgroup": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-5.3.0.tgz",
+      "integrity": "sha512-++j3Yi3XZGYgAvmGzRtNa+BnDvkPbdroyMffCY+Gj9A4iH2IJ1S7/g6LewGVXQkVw/KOzlfE1TimARYXvOEsgQ==",
+      "requires": {
+        "ambi": "^3.0.0",
+        "eachr": "^3.2.0",
+        "editions": "^1.3.4",
+        "extendr": "^3.2.2",
+        "unbounded": "^1.1.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "textextensions": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.4.0.tgz",
+      "integrity": "sha512-qftQXnX1DzpSV8EddtHIT0eDDEiBF8ywhFYR2lI9xrGtxqKN+CvLXhACeCIGbCpQfxxERbrkZEFb8cZcDKbVZA=="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
+    "typechecker": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.7.0.tgz",
+      "integrity": "sha512-4LHc1KMNJ6NDGO+dSM/yNfZQRtp8NN7psYrPHUblD62Dvkwsp3VShsbM78kOgpcmMkRTgvwdKOTjctS+uMllgQ==",
+      "requires": {
+        "editions": "^2.1.0"
+      }
+    },
+    "unbounded": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unbounded/-/unbounded-1.2.0.tgz",
+      "integrity": "sha512-D/ENuBtxxwhxEiSXHgHwM/UXsDRuXz7JwqBQ54zrbaqmbmSWPvsGMzslr5mEftsDo1KOfl7vEIXGCamWBlAT6Q==",
+      "requires": {
+        "editions": "^2.1.3"
+      }
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
+    "watchr": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/watchr/-/watchr-4.1.0.tgz",
+      "integrity": "sha512-ShaYIRazXv+4FjHNcjd6H8oyWcJnLh3M7Gle/7ZVj8WoMqBXU0xotCwxPFjEe8j92nozdBz0Q2hOrnp+U+55FA==",
+      "requires": {
+        "eachr": "^3.2.0",
+        "editions": "^2.1.0",
+        "extendr": "^3.2.2",
+        "ignorefs": "^1.1.1",
+        "safefs": "^4.1.0",
+        "scandirectory": "^3.0.1",
+        "taskgroup": "^5.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yamljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,10 +12,9 @@
   },
   "dependencies": {
     "docpad": "~6",
-    "docpad-plugin-eco": "~2.0.2",
-    "docpad-plugin-marked": "~2.1.1",
-    "docpad-plugin-highlightjs": "~2.1.8",
-    "docpad-plugin-growl": "~2.0.0"
+    "docpad-plugin-eco": "~2.3.0",
+    "docpad-plugin-marked": "~2.5.0",
+    "docpad-plugin-highlightjs": "~2.6.0"
   },
   "main": "node_modules/docpad/bin/docpad-server",
   "scripts": {

--- a/plugins/sproutdown/src/sproutdown.plugin.coffee
+++ b/plugins/sproutdown/src/sproutdown.plugin.coffee
@@ -129,7 +129,7 @@ module.exports = (BasePlugin) ->
       #
       # Wrap code blocks in a code container for styling
       #
-      opts.content = opts.content.replace(/<pre class="highlighted"><code/g, '<pre class="highlighted"><div class="code_container"><code')
+      opts.content = opts.content.replace(/<pre class="highlight"><code/g, '<pre class="highlighted"><div class="code_container"><code')
       opts.content = opts.content.replace(/<\/code><\/pre>/g, "</code></div></pre>")
       opts.content = opts.content.replace(/#(.*)filename[:=] ?(.*)/g, (match, p1, p2, offset, total_string)->
         return "<span class='comment'><div class='filename'>" + p2 + "</div></span>"

--- a/src/documents/adding_unit_test.html.md.sd
+++ b/src/documents/adding_unit_test.html.md.sd
@@ -11,6 +11,9 @@ sc_list:
   - Arrange your unit test files.
 ---
 
+NOTE: The way of interacting with the build tools has changed. Most of the generators are not included, which
+means that these files and folders need to be created by hand. Check out the Getting Started guides for
+which generators can be used. This guide will be updated as soon as possible to reflect these changes.
 
 ### Creating a Directory for Your Unit Test Files
 

--- a/src/documents/build_tools.html.md.sd
+++ b/src/documents/build_tools.html.md.sd
@@ -3,7 +3,7 @@ layout: default
 sc_category: Extras
 sc_order: 10
 sc_title: SproutCore's Build Tools
-sc_short_description: 
+sc_short_description:
 sc_description: After reading this guide, you will be able to:
 sc_list:
   - Create a new SproutCore project skeletons using <tt>sproutcore init</tt>.
@@ -15,21 +15,19 @@ sc_list:
 
 ### Introduction
 
-One of the least understood and, because of this, occasionally maligned
-components of SproutCore are the accompanying build tools.  Let's be clear,
-build tools are absolutely necessary for even the smallest project and to
-attempt to write an application without them from the start, simply means being
-forced to cobble together less effective processes later on.
+Many JavaScript frameworks use some kind of development environment,
+such as grunt, gulp, webpack or rollup. The reason for this is that it quickly
+becomes too difficult and time consuming to manage multiple source files and
+assets; there are several important optimizations required for deploying
+top-of-class web experiences that are best left to automated scripts.
 
-The reason for this is it quickly becomes too difficult and time consuming to
-manage multiple source files and assets; there are several important
-optimizations required for deploying top-of-class web experiences that are best
-left to automated scripts.
+SproutCore provides its own development environment, called build tools,
+or BT for short.
 
-For example, SproutCore's build tools do the following and more:
+BT provides the following and more:
 
 * Automatically scans your source code and builds a manifest of how your code
-  should be built into a final project.  This ensures that your JavaScript and
+  should be built into a final project. This ensures that your JavaScript and
   CSS always load in the proper order.
 * Run stylesheets through the [Compass CSS Authoring
   Framework](http://compass-style.org/) for simple and clean CSS.
@@ -43,8 +41,6 @@ For example, SproutCore's build tools do the following and more:
   single CSS file and minifies the contents of each.  This makes your deployed
   app load much faster since multiple smaller requests are slower for the
   clients.
-* Automatically slices and sprites your images; a typically very time-consuming
-  and error prone task.
 
 For a list of the available commands, type +sproutcore+ on the command line
 after installing the SproutCore gem:
@@ -52,187 +48,115 @@ after installing the SproutCore gem:
 ```bash
 $ sproutcore
 
-SproutCore 1.9.2 Usage
-======================
+  Usage: sproutcore [options] [command]
 
-Tasks:
-  sproutcore build [TARGET..]                                                                   # Builds one or more targets
-  sproutcore build-number TARGET                                                                # Computes a build number for the target
-  sproutcore docs [TARGET..]                                                                    # Generates JSDoc's for specified targets.
-  sproutcore gen generator Namespace[.ClassName] [--target=TARGET_NAME] [--filename=FILE_NAME]  # Generates SproutCore components
-  sproutcore help                                                                               # How to use the sproutcore command
-  sproutcore help [TASK]                                                                        # Describe available tasks or one specific task
-  sproutcore init PROJECT [APP]                                                                 # Generates a SproutCore project with an initial appl...
-  sproutcore manifest [TARGET..]                                                                # Generates a manifest for the specified targets
-  sproutcore server                                                                             # Starts the development server
-  sproutcore version                                                                            # Show the SproutCore version number
+  Options:
 
-Options:
-      [--project=PROJECT]
-      [--mode=MODE]
-      [--logfile=LOGFILE]
-  -b, [--build=BUILD]
-      [--build-targets=BUILD-TARGETS]  # Targets to build (excluding their dependencies)
-      [--dont-minify]                  # Disables minification for the build.
-  -v, [--verbose]
-  -V, [--very-verbose]
-      [--help]
+    -V, --version       output the version number
+    -h, --help          output usage information
+
+  Commands:
+
+    install [git-repo]  Install a repository, such as a framework
+    serve               Start the development server
+    build [app1]        Start the building process of one or more apps
+    gen <name>          Generate project structure or parts of it
+    init <name> [path]  Generate new project structure and app with the same name and an optional path
+    help [cmd]          display help for [cmd]
 ```
 
 ### Generating a New SproutCore Project: +sproutcore init+
 
 To create a new basic SproutCore project simply use +sproutcore init+ or its
 short form equivalent, +sc-init+, and supply a project name and optional
-initial app name.  If you don't supply the AppName parameter, an app with the
-same name as the project will be created.  For example, to create a project
-"MediaTools" with the default app "VideoEditor" use the following:
+path where to create it. If you don't supply the path parameter, the project
+will be created in a directory of the same name in the current directory.
+By default an application of the same name will be created in the projects
+app folder. Any additional app can be created using the `gen` command:
 
 ```bash
-$ sproutcore init MediaTools VideoEditor
- ~ Created directory at media_tools
- ~ Created file at media_tools/Buildfile
- ~ Created file at media_tools/README
- ~ Created directory at apps
- ~ Created directory at apps/video_editor
- ~ Created file at apps/video_editor/Buildfile
- ~ Created file at apps/video_editor/core.js
- ~ Created file at apps/video_editor/main.js
- ~ Created directory at apps/video_editor/resources
- ~ Created file at apps/video_editor/resources/_theme.css
- ~ Created file at apps/video_editor/resources/loading.rhtml
- ~ Created file at apps/video_editor/resources/main_page.js
- ~ Created file at apps/video_editor/theme.js
-Your new SproutCore project is ready!
-
-To get started, you can find your initial application in the "apps" directory.
+$ sproutcore init MediaTools
+  Your project has been successfully created!
+$ cd MediaTools
+$ sproutcore gen VideoEditor
 ```
-
-To create a project "Calculator" with an app of the same name, simply use:
-
-```
-$ sproutcore init Calculator
-~ Created directory at calculator
-~ Created file at calculator/Buildfile
-...
-```
-
-To create a project "BusyBee" with an app of the same name with a base
-statechart, simply use:
-
-```bash
-$ sproutcore init BusyBee --statechart
-~ Created directory at busy_bee
-~ Created file at busy_bee/Buildfile
-...
-```
-
-NOTE: Passing a camelcase app name to +sproutcore init+, such as
-`VideoEditor` &mdash; notice the uppercase 'E' &mdash; creates a
-namespace `VideoEditor` and the directories are named using
-underscores (i.e. *+apps/video_editor+*).
 
 ### Generating Additional SproutCore Files: +sproutcore gen+
 
 The command `sproutcore init` creates a few default files for you
 that form a typical starting point for a new project, but you will soon need
-other files and this is where the command +sproutcore gen+ or +sc-gen+, for
-short, can come in.  The following are the most commonly used commands with a
-brief description of each.
+other files and this is where the command +sproutcore gen+ can come in.
 
-#### +sc-gen project ProjectName+
-
-Creates an empty SproutCore project.  You may use this instead of
-`sproutcore init`, if you don't want a default app to be created.
-
-#### +sc-gen app AppName+
+#### +sproutcore gen app AppName+
 
 When called from within a project, adds an app to the project with the
 namespace `AppName`.
 
-#### +sc-gen statechart_app AppName+
-
-When called from within a project, adds an app with a basic SC.Statechart
-setup.
-
-NOTE: Similar to generating basic statechart files with `sproutcore init
---statechart` you can achieve the same result with `sproutcore gen
-app --statechart`.
-
-#### +sc-gen model AppName.ModelName+
-
-Adds a SC.Record subclass, 'AppName.ModelName', in the file
-`model_name_model.js` along with stub fixture and unit test files.
-
-#### +sc-gen controller AppName.ControllerName+
-
-Adds a SC.ObjectController subclass instance, 'AppName.controllerName', in the
-file `controller_name_controller.js` and a stub unit test file.
-
-#### +sc-gen view AppName.ViewName+
-
-Adds a SC.View subclass, 'AppName.ViewName', in the file
-`view_name_view.js` and a stub unit test file.
-
-#### +sc-gen data-source AppName.DataSourceName+
-
-Adds a SC.DataSource subclass, 'AppName.DataSourceName', in the file
-`data_source_name.js`.
-
-#### +sc-gen language AppName.Language+
-
-Adds a language file for 'Language', in the file `language.lproj`.
-Here are some examples:
-
-```bash
-$ sc-gen language MediaTools French
- ~ Created directory at french.lproj
- ~ Created file at french.lproj/strings.js
-
-$ sc-gen language MediaTools en-ca
- ~ Created directory at en_ca.lproj
- ~ Created file at en_ca.lproj/strings.js
-
-$ sc-gen language MediaTools Latin
- ~ Created directory at Latin.lproj
- ~ Created file at Latin.lproj/strings.js
-```
-
-NOTE: Generally the provided 'Language' will result in the same named
-directory, 'Language.lproj', but as can be seen by the French example above,
-the build tools have a bit of an odd behavior of recognizing English, French,
-German, Italian, Spanish and Japanese as parameters and making the directory
-name the lowercase version.
-
-#### +sc-gen framework FrameworkName+
-
-Creates a framework with namespace `FrameworkName` in the project's
-`frameworks` directory.  Read further to learn about including
-frameworks in your SproutCore apps.
-
-### Configuring SproutCore Applications: +Buildfile+
+### Configuring SproutCore Applications: +sc_config+
 
 The operations of the build tools are configured via the project, framework and
-app Buildfiles.  If you used the previous commands, you will find a Buildfile
-within your root project directory and a Buildfile in each of your app
-directories.  As it states in the default app Buildfiles, the settings in the
-app Buildfile will override the project Buildfile.
+app sc_config files.  If you used the previous commands, you will find a sc_config
+within your root project directory and a sc_config in each of your app
+directories.
 
-Therefore, a recommended setup would configure properties shared between all
-your apps within a project in the project's Buildfile and to configure any
-properties specific to an app, in the app's Buildfile.  For simplicity state,
-the following examples will just use a single Buildfile in most cases.
+Before we look at the contents of the configuration files, it is important to realize
+that the BT essentially functions in two modes: a 'debug' mode and a 'build' mode.
+The debug mode is the mode where the BT is used to provide a dev server. The
+build mode is the mode when you use the BT to generate HTML, CSS and JS files on disk.
 
-Before looking at each config setting in detail, there is one important
-statement, +mode+, that is valuable to understand.  Any configurations within a
-`mode #{name}` block will only apply to the named environment.  By
-default, `sproutcore build` uses the mode +production+ and
-`sproutcore server` uses the mode +debug+, but you may provide any
-custom mode by passing +--mode=my_mode+ to the command.
+We start by looking at the sc_config file in the application directory root. The default file
+generated by the BT looks like this:
 
-The following list describes the most common Buildfile `config`
-properties.
+```javascript
+var TodosOne = BT.AppBuilder.create({
+  name: 'TodosOne',
+  path: dirname(),
+  title: 'TodosOne',
+  frameworks: [],
+  languages: ['en'],
+});
+```
 
-#### +:build_number => {String}+
+The following list describes the most common properties.
+
+#### +name: 'TodosOne'+
+
+The name of the project as it should be recognized by the BT. Any files created
+during the build phase will carry this name, as well as the base url in the
+dev server.
+
+#### +path: dirname()+
+
+By default `dirname()` will fill in the current path of the sc_config file. There
+can be reasons to have the BT load a different path for this app.
+
+#### +title: 'TodosOne'+
+
+The title you want the app to have in the generated HTML.
+
+#### +frameworks: []+
+
+The list of frameworks your app depends on. A default set of SproutCore frameworks will be
+included by default. The BT will look for the frameworks in the projects frameworks folder.
+Using the name of the framework folder is usually sufficient. In case you want to be
+selective, and only use selected frameworks from a frameworks bundle (such as SproutCore),
+use `:` to seperate the framework names. To use the experimental select views framework for
+example, you would include `'sproutcore:experimental:select_ext'` in the frameworks list.
+
+#### +languages: []+
+
+List of languages this app will support.
+
+#### +language: {String}+
+
+Which language the BT will use when serving the app through the dev server.
+
+
+#### +theme: {String}+
+
+The theme your application will use. The default is ``sproutcore:aki'`.
+
+#### +buildNumber: ''+
 
 By default, the build project assets will get cache friendly paths containing a
 unique build number.  This is necessary to ensure that the files are properly
@@ -241,161 +165,46 @@ cached, but you can specify a custom build number with this setting.
 WARNING: Using a fixed build_number will cause cached assets to not be
 invalidated.  Use this setting with caution.
 
-#### +:combine_javascript => {Boolean}+
+#### +combineScripts: {Boolean}+
 
-By default, the built project combines all the JavaScript files into a single
-file.  Setting `:combine_javascript` to `false` will
-prevent this from happening, which may be useful for debugging purposes.
+Whether the BT should combine the scripts in a single file. By default, this
+setting is false in debug mode, and true in build mode. Setting `combineScripts`
+to `false` will prevent the combining in build mode, which may be useful for debugging purposes.
 
-#### +:combine_stylesheets => {Boolean}+
+#### +combineStylesheets: {Boolean}+
 
-By default, the built project combines all the CSS files into a single file.
-Setting `:combine_stylesheets` to `false` will prevent
-this from happening, which may be useful for debugging purposes.
+By default, the BT in build mode combines all the CSS files into a single file.
+Setting `combineStylesheets` to `false` will prevent this from happening,
+which may be useful for debugging purposes.
 
-#### +:javascript_libs => {Array}+
+#### +minifyScripts: {Boolean}+
 
-An array of JavaScript file URLs that will be inserted as the src attributes of
-`<script>` tags in the `<head>` element.
+By default, the BT in build mode will minify all scripts.
+Setting `minifyScripts` to `false` will prevent this from happening,
+which may be useful for debugging purposes.
 
-Ex. Including the Google Maps API:
+#### +minifyStylesheets: {Boolean}+
 
-```ruby
-# filename: my_project/apps/my_app/Buildfile
-config :my_app, :javascript_libs => [
-  'https://maps.googleapis.com/maps/api/js?v=3&sensor=false'
-]
-```
+By default, the BT in build mode will minify all stylesheets.
+Setting `minifyStylesheets` to `false` will prevent this from happening,
+which may be useful for debugging purposes.
 
-#### +:layout => {String}+
+#### +contentForPageStyles: {String}+
 
-By default, SproutCore apps use the index.html template in the SproutCore
-framework at `lib/index.rhtml`.  You may copy the default
-index.rhtml file into your app and specify the path in your Buildfile.
+Insert here any HTML which should be inserted together with the styles.
 
-WARNING: Failing to update your copy of index.rhtml when SproutCore is updated,
-may cause conflicts with the build tools.  Therefore it is recommended to use
-the config parameters to modify the generated index.html, rather than modifying
-the template directly.
+#### +contentForPageJavaScript: {String}+
 
-#### +:load_debug => {Boolean}+
+Use this to include script tags to third party scripts not to be included
+in the HTML, CSS and JS files generated by the BT.
 
-By default, directories named `debug` are not included in the built
-project.  Set `:load_debug` to `true` to have them
-included.
-
-#### +:load_fixtures => {Boolean}+
-
-By default, fixtures are excluded in the built project.  Set
-`:load_fixtures` to `true` to have them included.
-
-#### +:load_protocols => {Boolean}+
-
-By default, files in directories named `protocols` are excluded in
-the built project.  Set `:load_protocols` to `true` to
-have them included.
-
-#### +:minify => {Boolean}+
-
-By default, the HTML, JavaScript and CSS is minified when built.  Set this to
-`false` to prevent minification, which may be useful for debugging.
-You can also be more specific by using either +:minify_javascript+,
-+:minify_css+ or +:minify_html+.
-
-NOTE: If minify is `false`, `sc-build` will throw a
-security exception unless `--allow-commented-js` is set, because all
-comments will be visible in the built product.
-
-#### +:required => {Array}+
-
-This defines the frameworks in the order that the app requires them and is
-initially set by default to `:sproutcore`.  Since frameworks can be
-nested and can define their own requirements, the `:sproutcore`
-framework is actually just a wrapper framework that includes several of its
-sub-frameworks each of which have their own requirements as well.  New
-developers should not generally concern themselves with stripping away
-
-Ex. The most basic Buildfile:
-
-```ruby
-# filename: my_project/Buildfile
-config :all, :required => :sproutcore
-```
-
-Ex. Including a framework, DataHelpers, from the project's frameworks directory for all apps within the project:
-
-```ruby
-# filename: my_project/Buildfile
-config :all, :required => [:sproutcore, :data_helpers]
-```
-
-Ex. Including different frameworks for different apps:
-
-```ruby
-# filename: my_project/Buildfile
-config :all, :required => [:sproutcore]
-
-config :my_app, :required => [:client_views]
-
-config :my_admin_app, :required => [:admin_tools]
-```
-
-Ex. Including different frameworks for different apps using app specific Buildfiles:
-
-```ruby
-# filename: my_project/Buildfile
-config :all, :required => [:sproutcore]
-```
-
-```ruby
-# filename: my_project/apps/my_app/Buildfile
-config :my_app, :required => [:client_views]
-```
-
-```ruby
-# filename: my_project/apps/my_admin_app/Buildfile
-config :my_admin_app, :required => [:admin_tools]
-```
-
-INFO: For advanced manipulation of the included SproutCore frameworks, refer to
-the SproutCore
-[Buildfile](https://github.com/sproutcore/sproutcore/blob/master/Buildfile).
-
-#### +:theme => {String}+
-
-The framework or theme that contains the app's theme.  See the guide on
-[Theming Your App](/theming_app.html) for more information.
-
-#### +:theme-name => {String}+
-
-A class name to set on the `<body>` element.  If not specified, the
-body will have a class `sc-theme`.
-
-#### +:title => {String}+
-
-The value of the HTML `<title>` element.
-
-Ex. Separate titles for different apps:
-
-```ruby
-# filename: my_project/Buildfile
-config :all, :required => [:sproutcore]
-
-config :my_app, :title => 'My App'
-
-config :my_admin_app, :title => 'My App (Administration)'
-```
-
-INFO: For advanced Buildfile configuration, refer to the build tool's
-[Buildfile](https://github.com/sproutcore/abbot/blob/master/lib/Buildfile).
-
-### Developing with SproutCore: +sproutcore server+
+### Developing with SproutCore: +sproutcore serve+
 
 So that you can view and test your code in action immediately, the build tools
 also provide a local server and proxy.  As was mentioned in [Getting
 Started](/getting_started.html), you run the server by changing to your
-project's directory and running either +sproutcore server+ or +sc-server+ for
-short.  The server will monitor your files for changes and re-build them when
+project's directory and running +sproutcore serve+.
+The server will monitor your files for changes and re-build them when
 they do change.  To keep the process fast and to allow you to debug your code
 while developing, the individual files aren't packed or minified in debug mode.
 When your server is running, you can access your apps at
@@ -412,37 +221,51 @@ will use the SproutCore server to proxy the request across.
 
 Here are some examples configuring the SproutCore server proxy:
 
-```ruby
-# filename: my_project/Buildfile
-# Proxy all requests for '/news' to 'http://news.com/news'.
-proxy "/news", :to => "news-server.com"
+```javascript
+// filename: my_project/sc_config
+BT.serverConfig = {
+  proxies: [
+    // Proxy all requests for '/news' to 'http://news.com/news'.
+    {
+      prefix: '/news',   // set a prefix here for the development server
+      host: 'news.com', // to which host should the request be forwarded
+      port: 80, // on which port is the host listening?
+      logRequests: false, // show the requests in the terminal?
+      proxyPrefix: '/news' // replace the prefix set above with this
+    },
+    // Proxy all requests for '/session' to 'https://session-server.net/session'.
+    {
+      prefix: '/session',   // set a prefix here for the development server
+      host: 'session-server.net', // to which host should the request be forwarded
+      port: 443, // on which port is the host listening?
+      logRequests: false, // show the requests in the terminal?
+      proxyPrefix: '/session' // replace the prefix set above with this
+      secure: true,
+    },
+      // Proxy all requests not matching anything in the BT to 'https://session-server.net/session'.
+    {
+      prefix: '/',   // set a prefix here for the development server
+      host: 'session-server.net', // to which host should the request be forwarded
+      port: 443, // on which port is the host listening?
+      logRequests: false, // show the requests in the terminal?
+      proxyPrefix: '/session' // replace the prefix set above with this
+      secure: true,
+    },
+  ]
 
-# Proxy all requests for '/session' to 'https://session-server.net/session'.
-proxy "/session", :to => "session-server.com", :secure => true
+}
 
-# Proxy all requests for '/users' to 'https://our-app.com/people'.
-#   ex. /users/23 => https://our-app.com/people/23
-proxy "/users", :to => "our-app.com", :secure => true, :url => "/people"
 
-# Proxy to a local server with a longer timeout to support long-polling requests.
-#   ex. /socket.io => http://localhost:3443/socket.io
-proxy '/socket.io', :to => 'localhost:3443', :timeout => 25
-
-# An alternate configuration of the above.
-proxy '/socket.io', :to => 'localhost:3443', :connect_timeout => 5, :inactivity_timeout => 30
-
-# Disallow redirects
-proxy '/originals', :to => 'some-api.org', :redirect => false
 ```
 
-NOTE: When changing proxy settings, the server may need to be restarted to
+NOTE: When changing proxy settings, the dev server needs to be restarted to
 reflect the changes.
 
 ### Building a SproutCore Application: +sproutcore build+
 
 Finally, when your application is ready to be deployed to a real server, you
 will do a production build and move the files across to be hosted.  Depending
-on the options you set in your Buildfile, this will generate some variant of
+on the options you set in your sc_config file, this will generate some variant of
 static deployable and cache-able content.
 
 Ex. Building all apps and required frameworks within a project.
@@ -457,60 +280,107 @@ Ex. Building a specific app within a project, including it's required frameworks
 $ sproutcore build my_app
 ```
 
-The following are some options that you may want to pass to +sproutcore build+
-or +sc-build+.
+We take one last look at the sc_config file in your project directory.
+You will notice the familiar `sc_require()` call in the top of the file.
+The BT will not include any app in your project unless you specifically indicate
+you want to include it. If you want to temporarily remove an app from the project,
+simply comment out the sc_require line from the projects sc_config file.
 
-#### +--allow-commented-js+
+Here are some useful settings:
 
-You must set this if you have set `minify: false` in your Buildfile
-and you do want to build an un-minified product which includes all your
-comments.
+#### +port: {Number}+
 
-#### +--build+
-
-Specify the build number manually to use. This results in paths that won't
-cache properly, but may be useful for testing or embedding a SproutCore app.
-
-```bash
-$ sproutcore build my_app --build=test_build
-```
-
-#### +--buildroot+
-
-Specify the path to the built product.
+Set this to the port you want to run the dev server on. The default value is 4020.
+You can temporarily override this setting on the command line:
 
 ```bash
-$ sproutcore build my_app --buildroot=../builds
+sproutcore serve -p 4021
 ```
 
-#### +--languages+
+#### +localOnly: {Boolean}+
 
-Specify which languages to build.  By default, the build tool will build all
-languages in the project.
+By default, the dev server will only be available on your computers special
+localhost domain, and therefore hidden for the rest of the network you might be in.
+If you want to be able to test your application from a different computer, set
+the localOnly value to false and restart the dev server. This will make the
+dev server listen on the defined port on all network interfaces.
 
-```bash
-$ sproutcore build my_app --languages=en,en-ca,zh
+WARNING: Do not use this feature to host a sproutcore application for production
+purposes! Any normal web server hosting a built SproutCore application will
+outperform the dev server by miles and will be much more secure.
+
+```javascript
+sc_require('apps/TodosOne/sc_config')
+
+/*
+Please don't remove the following server configuration, as the build tools use it to
+determine the root of your project.
+ */
+
+BT.serverConfig = {
+
+  /**
+    The port on which the development server should run
+
+    @property
+    @type Number
+    @default 4020
+  */
+  port: 4020,
+
+  /**
+    Set it to false to allow access from the network.
+
+    @property
+    @type Boolean
+    @default true
+  */
+  localOnly: true,
+
+  /**
+    A JSON file to use to store build numbers.
+    You must define this property to enable build number support.
+
+    Example:
+
+        buildNumberPath: 'build_number.json',
+
+    @property
+    @type String
+    @default null
+  */
+  buildNumberPath: null,
+
+  /**
+    Define this property if you need one or more proxies.
+    If you do a request from your app (file or XHR) which doesn't match anything the BT provide,
+    the request will be run past the proxies in the order you define them here.
+    You can use the prefix to filter which requests will be forwarded to where.
+    In the proxied request the prefix you define will be replaced by the proxyPrefix.
+    The example shows how to set up a catch-all proxy, in this case to CouchDB.
+    You can set as many proxies as you want, as long as they don't share a prefix.
+
+    Example:
+
+        proxies: [
+          {
+            prefix: '/',   // set a prefix here for the development server
+            host: 'localhost', // to which host should the request be forwarded
+            port: 5984, // on which port is the host listening?
+            logRequests: false, // show the requests in the terminal?
+            proxyPrefix: '/' // replace the prefix set above with this
+          }
+        ]
+
+    @property
+    @type Array
+    @default null
+  */
+  proxies: null
+
+}
+
 ```
-
-#### +--dont-minify+
-
-Disables minification for the build without throwing a Security exception as
-setting +minify: false+ within the Buildfile would do.
-
-WARNING: Be sure to remove any +debugger+ statements from your code, as they
-will cause the build to fail.
-
-#### +--stageroot+
-
-Specify the path to the staging products.
-
-```bash
-$ sproutcore build my_app --stageroot=../tmp/staging
-```
-
-#### +--verbose+ or +-v+
-
-Verbose output.
 
 ### Changelog
 
@@ -518,3 +388,4 @@ Verbose output.
 * February 28, 2012: added some documentation on sc-server & sc-build by [Tyler Keating](credits.html#publickeating)
 * December 17, 2012: added note about changing proxy settings by [Mike Atkins](credits.html#apechimp)
 * July 14, 2013: converted to Markdown format for DocPad guides by [Topher Fangio](credits.html#topherfangio)
+* January 17, 2019: Updated to document the NodeJS based BT by [Maurits Lamers](credits.html#mauritslamers)

--- a/src/documents/credits.html.md.sd
+++ b/src/documents/credits.html.md.sd
@@ -6,12 +6,12 @@ sc_title: Credits
 sc_short_description: The People That Make It Happen
 sc_credits:
   - name: Documentation Team
-    authors: 
+    authors:
     - fname: Topher
       lname: Fangio
       github: topherfangio
   - name: Contributors
-    authors: 
+    authors:
     - fname: Mike
       lname: Atkins
       github: apechimp
@@ -35,7 +35,7 @@ sc_credits:
       github: tomdale
     - fname: Geoffrey
       lname: Donaldson
-      github: geoffreyd 
+      github: geoffreyd
     - fname: Chad
       lname: Eubanks
       github: ChadEubanks
@@ -87,4 +87,7 @@ sc_credits:
     - fname: Jeff
       lname: Pittman
       github: geojeff
+    - fname: Maurits
+      lname: Lamers
+      github: mauritslamers
 ---

--- a/src/documents/fixtures.html.md.sd
+++ b/src/documents/fixtures.html.md.sd
@@ -47,9 +47,6 @@ App.MyModel.FIXTURES = [
 SproutCore looks for fixtures assigned specifically to a model (i.e. +App.MyModel.FIXTURES+ on the above example). By convention, fixtures are defined
 in the +app/fixtures+ folder of your application (i.e. +app/fixtures/my_model.js+). By default fixtures are not included in production builds.
 
-NOTE: If you use +sc-gen+ to create your models then you may have noticed that some placeholder fixtures already exist. You will still need to modify
-these fixtures to suit your needs. Read on to learn how.
-
 ### Writing Your Own Fixtures
 
 Writing fixtures is relatively straightforward. Each item representing a record gets its own hash in the format of +propertyName: value+. If your
@@ -206,3 +203,4 @@ And that's it! Your fixtures should now be available to your data store!
 * March    2, 2011: added filenames and fixed code formatting by [Topher Fangio](credits.html#topherfangio)
 * July    17, 2011: minor changes by [William Estoque](credits.html#westoque)
 * October 23, 2013: converted to Markdown format for DocPad guides by [Topher Fangio](credits.html#topherfangio)
+* January 17, 2019: removed reference to sc-gen by [Maurits Lamers](credits.html#mauritslamers)

--- a/src/documents/getting_started.html.md.sd
+++ b/src/documents/getting_started.html.md.sd
@@ -15,34 +15,19 @@ sc_list:
 
 ### Introduction
 
-The introductory "Getting Started" guides pages are step-by-step treatments of concepts needed to make a full 
-SproutCore application. 
+The introductory "Getting Started" guides pages are step-by-step treatments of concepts needed to make a full
+SproutCore application.
 
-This first "Getting Started" guide will ensure that you have the latest version of Sproutcore installed and 
+This first "Getting Started" guide will ensure that you have the latest version of Sproutcore installed and
 configured properly. If you run into any issues or bumps along the way, please reach out on the
-[mailing list](http://groups.google.com/group/sproutcore) or find us on IRC at #sproutcore!
+[mailing list](http://groups.google.com/group/sproutcore), find us on IRC at #sproutcore or leave a message on [Gitter](https://gitter.im/sproutcore/sproutcore)!
 
 ### Installation
 
-There are two basic ways to install SproutCore.
+To install the SproutCore development environment you need to have [NodeJS](http://nodejs.org/) and NPM installed.
+The latest version of NodeJS currently supported by this environment is 9.x.
 
-* The Package Installers
-* Using RubyGems
-
-The installation method you choose should be based upon your current platform and your experience with Ruby.
-The installers are currently only available for Windows and Mac. Linux and other platforms should use the
-RubyGems method. 
-
-Additionally, if your machine is already setup for development in Ruby, you may find it more
-convenient to forgo the package installers, and use RubyGems so that you can always get the latest
-version by typing the following:
-
-```bash
-gem update sproutcore
-```
-
-So, before you move on, please visit the [Installation Page](http://sproutcore.com/install/) and either
-download the appropriate package, or follow the guide for your platform.
+Please visit the [Installation Page](http://sproutcore.com/install/) and follow the guide for your platform.
 
 Great! Now that SproutCore is installed, we can move forward and get our first app up-and-running!
 
@@ -60,19 +45,13 @@ NOTE: The dollar sign ($) in the code above and below represents the command lin
 be typed when executing the commands. Lines without a prompt generally show you the output of the previous
 command.
 
-This directory can serve as a place for all things SproutCore. Change directory to ~/development/sproutcore, then
+This directory can serve as a place for all things SproutCore. Change directory to `~/development/sproutcore`, then
 create a SproutCore project:
 
 ```bash
 $ cd ~/development/sproutcore
-$ sproutcore gen project getting_started
-
-   ~ Created directory at getting_started
-   ~ Created file at getting_started/Buildfile
-   ~ Created file at getting_started/README
-
-   Your project is now ready to use!
-
+$ sproutcore init getting_started
+  Your project has been successfully created!
 $ cd getting_started
 ```
 
@@ -84,36 +63,31 @@ Create the app in the getting_started project directory:
 
 ```bash
 $ sproutcore gen app TodosOne
-   ~ Created directory at apps
-   ~ Created directory at apps/todos_one
-   ~ Created file at apps/todos_one/Buildfile
-   ~ Created file at apps/todos_one/core.js
-   ~ Created file at apps/todos_one/main.js
-   ~ Created directory at apps/todos_one/resources
-   ~ Created file at apps/todos_one/resources/_theme.css
-   ~ Created file at apps/todos_one/resources/loading.rhtml
-   ~ Created file at apps/todos_one/resources/main_page.js
-   ~ Created file at apps/todos_one/theme.js
-
-  Your application target is now ready to use!
+  App TodosOne generated
 ```
 
 Your directory structure should now look like the following:
 
 
- * ** getting_started/**
-   * ** Buildfile**
-   * ** README.md**
-   * ** apps/**
-     * ** todos_one/**
-       * ** Buildfile**
-       * ** core.js**
-       * ** main.js**
-       * ** theme.js**
-       * ** resources/**
-         * ** _theme.css**
-         * ** loading.rhtml**
-         * ** main_page.js**
+  * **getting_started/**
+    * **sc_config**
+    * **apps/**
+      * **TodosOne/**
+        * **sc_config**
+        * **core.js**
+        * **main.js**
+        * **theme.js**
+        * **statechart.js**
+        * **controllers/**
+        * **fixtures/**
+        * **views/**
+        * **states/**
+          * **ready_state.js**
+        * **resources/**
+          * **_theme.css**
+          * **loading.ejs**
+          * **main_page.js**
+          * **main_page.css**
 
 ### Explanation
 
@@ -125,9 +99,9 @@ e-mail, contacts and finding your friends.
 This is why there is an **apps/** directory inside of the getting_started project directory. It
 allows you to easily separate distinct applications.
 
-Inside the **apps/todos_one** directory, you will find the Buildfile for the TodosOne application.
-Just like the project (getting_started) has a **Buildfile**, each application or
-framework that you create should also have a **Buildfile** which specifies it's
+Inside the **apps/TodosOne** directory, you will find the sc_config for the TodosOne application.
+Just like the project (getting_started) has a **sc_config**, each application or
+framework that you create should also have a **sc_config** which specifies it's
 requirements as well as any build-options that you may want to change, such as
 whether or not to minify and compact the code.
 
@@ -136,17 +110,16 @@ application is defined. This is also where you usually define any global
 constants that the application might use (which should be very few), or any
 configuration that external libraries might require.
 
-The **main.js** file is usually very basic. It starts the application. If you
-are using the Statechart framework (which we will discuss in Part 2), **main.js**
-would simply initialize the statechart. If you open up **main.js** right now,
-you'll see that it appends the main view to the screen.
+The **main.js** file is usually very basic. It starts the application. The default
+assumes you are using the Statechart framework (which we will discuss in Part 2).
+**main.js** simply initializes the statechart, which you will see if you open up **main.js** right now.
 
 The resources folder contains things like images, stylesheets and views.
 
 Inside the resources folder, the **_theme.css** file defines that directory's
 CSS theme. This allows you to define different themes for each directory.
 
-The **resources/loading.rhtml** file defines the HTML that your users see before
+The **resources/loading.ejs** file defines the HTML that your users see before
 SproutCore has fully loaded and handed control over to the application. For
 now, it displays a simple loading message.
 
@@ -157,6 +130,15 @@ you may decide you want to break it out a bit more by having a loadingPane,
 loggedInPane, loggedOutPane, etc. Most applications have at least a few
 panes, and possibly a few pages.
 
+### Installing the SproutCore framework
+
+```bash
+$ sproutcore install sproutcore frameworks
+```
+
+This installs the SproutCore framework inside the frameworks folder of your
+project.
+
 ### Viewing Your Application
 
 So, we have our SproutCore TodosOne application built, and we understand the basic
@@ -165,16 +147,16 @@ layout of the files. Let's see what it looks like in the browser!
 Inside the project directory type the following command:
 
 ```bash
-$ sproutcore server
+$ sproutcore serve
 ```
 
-NOTE: If you are attempting to run multiple copies of **sproutcore server** at the same
+NOTE: If you are attempting to run multiple copies of **sproutcore serve** at the same
 time, you will probably see an error about the port already being in use. If
-so, just re-run the command and add --port 4030 so the second instance will not use 
+so, just re-run the command and add --port 4030 so the second instance will not use
 the default 4020 port.
 
 Using your favorite web browser, visit
-http://localhost:4020/todos_one. If all goes
+http://localhost:4020/TodosOne. If all goes
 well, you should see "Welcome to Sproutcore!" in the middle of the screen.
 
 ### Making Changes
@@ -190,20 +172,10 @@ As with any unfamiliar framework, you may hit a few snags on the way. Below
 we list some of the common pitfalls that users have discovered, with
 solutions for getting past them.
 
-* *"Error: Handlebars is not defined Source File: ..."* - If you have previously
-installed SproutCore 1.6 using the installer, you may see this error. If so, please make
-sure to un-install SproutCore 1.6 first and then re-install 1.8.
-
-* *"RuntimeError at /todos_one html_builder could not find a layout file for ..."* -
-This error usually means that **sproutcore server** could not find SproutCore where it
-thought it should exist. Make sure that you've properly installed the latest
-version of SproutCore; and if you are using RubyGems, try closing and
-re-opening the terminal to ensure that paths are properly set.
-
 * *"Browser says 'No matching target'"* - This is generally caused if you
 misspelled the name of the application in the URL. Make sure that you properly
 typed it, and that you used underscores instead of spaces. For example:
-http://localhost/todos_one.
+http://localhost/TodosOne.
 
 * *"ERROR: missing } after property list ..."* - This error is usually thrown
 if you added a property somewhere, but forgot to put a comma at the end.
@@ -224,5 +196,6 @@ a comma missing.
 * March 6, 2012: rewrite for SproutCore 1.8 by the 1.8 release sprint team, including the following who did
   much work on this task: [Tim Evans](credits.html#tce), [Topher Fangio](credits.html#topherfangio) and [Jeff Pittman](credits.html#geojeff)
 * March 12, 2012: added new error and fixed italics in the troubleshooting section by [Topher Fangio](credits.html#topherfangio)
-* July 30, 2013: converted to Markdown format for DocPad guides by [Eric Theise](credits.html#erictheise) 
+* July 30, 2013: converted to Markdown format for DocPad guides by [Eric Theise](credits.html#erictheise)
 * July 30, 2013: fix issues with formatting and updated Changelog by [Topher Fangio](credits.html#topherfangio)
+* January 17, 2019: Change to NPM build tools.

--- a/src/documents/getting_started_2.html.md.sd
+++ b/src/documents/getting_started_2.html.md.sd
@@ -347,7 +347,7 @@ as the initialization and the transition to the readyState.
 You are now ready to move on to creating a full-scale SproutCore app!
 
 [Part 3](/getting_started_3.html) will introduce you to a more complete Todos application,
-called TodosTwo, and walk you through the process of building it from scratch.
+called TodosThree, and walk you through the process of building it from scratch.
 You will learn about models, controllers and how they tie in with the statechart
 and views.
 
@@ -362,4 +362,4 @@ Dive in to [Getting Started: Part 3](/getting_started_3.html).
   [Jeff Pittman](credits.html#geojeff)
 * July 30, 2013: converted to Markdown format for DocPad guides by [Eric Theise](credits.html#erictheise)
 * July 30, 2013: fix issues with formatting and updated Changelog by [Topher Fangio](credits.html#topherfangio)
-* Jan 17, 2019: Update the guide as the default application already uses the state chart.
+* Jan 17, 2019: Updated the guide as the default application already uses the state chart by [Maurits Lamers](credits.html#mauritslamers)

--- a/src/documents/getting_started_2.html.md.sd
+++ b/src/documents/getting_started_2.html.md.sd
@@ -9,7 +9,6 @@ In Part 2, you will:
 
 sc_list:
   - Learn about statecharts and how they can improve your application.
-  - Create a new statechart-based SproutCore application, TodosTwo.
   - Learn about views and how they should handle events.
   - Learn how to separate views in individual files with the use of <em>sc_require()</em>.
   - Learn how to pass events to the application's statechart.
@@ -28,7 +27,7 @@ how your app would react under a particular set of conditions.
 
 Statecharts help reduce uncertainty, by defining more explicitly what can and cannot happen
 within your application. You think of discrete states, such as "showing login panel." You think
-of transitions between states. For example, you would think about what should happen as the login 
+of transitions between states. For example, you would think about what should happen as the login
 panel is shown, what could happen while it is showing, and what should happen when it is taken down.
 
 ### What is a Statechart?
@@ -62,19 +61,19 @@ In the list above, the states are in ALL-CAPS, the actions are in italics.
 INFO: The Getting Started Todos applications use ALL_CAPS for state names, for the sake of continuity.
 However, states are standard SC objects and can follow any naming convention you want.  Many developers
 prefer CamelCase (i.e., MyApp.LoggedInState) while others prefer namespacing their states (i.e.,
-MyApp.States.LoggedIn).  Some prefer verb-style over noun-style state names. Whatever method you 
+MyApp.States.LoggedIn).  Some prefer verb-style over noun-style state names. Whatever method you
 choose is fine, just be consistent, so you, and other developers, can more easily follow your code.
 
-NOTE: The term state is generic: you can use state to refer to states and substates. When you use the term substate, 
+NOTE: The term state is generic: you can use state to refer to states and substates. When you use the term substate,
 the reference is more specific, and is relative to a parent state.
 
 #### Decoding the Statechart
 
-In our mapping example here, the application can be in one of the two top level states: LOADING or LOADED. If 
-it is in one of these states, it cannot be in the other. When it is in the LOADING state, the only available 
-action is the _loadingFinished_ action. The statechart/application should not respond to any other events. 
-Once control moves into the LOADED state, it can move to two additional states, substates of the LOADED 
-state: LOGGED_OUT or LOGGED_IN. Again, the program can only be in one at a given time, so when the user is 
+In our mapping example here, the application can be in one of the two top level states: LOADING or LOADED. If
+it is in one of these states, it cannot be in the other. When it is in the LOADING state, the only available
+action is the _loadingFinished_ action. The statechart/application should not respond to any other events.
+Once control moves into the LOADED state, it can move to two additional states, substates of the LOADED
+state: LOGGED_OUT or LOGGED_IN. Again, the program can only be in one at a given time, so when the user is
 "logged out", after the application has loaded, the only available action is the _login_ action.
 
 However, notice that the _viewTermsOfService_ action and the _viewPrivacyPolicy_ action are both available in
@@ -82,7 +81,7 @@ the LOADED state. This means that regardless of whether the program is in the LO
 state, the user should be allowed to view the terms of service or the privacy policy.
 
 Once the user has authenticated and logged in, they have various actions available in the mapping system.
-Imagine a map user interface that appears, with buttons in a dashboard, with live clickable elements on the map, etc. 
+Imagine a map user interface that appears, with buttons in a dashboard, with live clickable elements on the map, etc.
 The example actions given above, _createBasemap_, _zoomMapView_, and _showPointData_ are just a sample of what
 would be many actions tied to user interface elements.
 
@@ -94,56 +93,12 @@ data import system in our mapping example could be programmed using statecharts.
 An application only responds to certain actions at certain times. This makes it
 much easier to verify that an app is working properly, by ensuring that events are handled exactly when they
 need to be handled. Furthermore, if, say, a bug in the design of the user interface allows an action to happen
-when it shouldn't (like allowing some action when the user is logged out), the application itself may maintain 
+when it shouldn't (like allowing some action when the user is logged out), the application itself may maintain
 a consistent state and continue to operate. Programming with statecharts can help isolate parts of the system.
 
-### Creating the Statechart
-
-Create a statechart-based SproutCore app with the **sproutcore gen statechart_app** command:
-
-```bash
-$ cd ~/development/sproutcore/getting_started
-$ sproutcore gen statechart_app TodosTwo
-   ~ Created directory at apps/todos_two
-   ~ Created file at apps/todos_two/Buildfile
-   ~ Created file at apps/todos_two/core.js
-   ~ Created file at apps/todos_two/main.js
-   ~ Created directory at apps/todos_two/resources
-   ~ Created file at apps/todos_two/resources/_theme.css
-   ~ Created file at apps/todos_two/resources/loading.rhtml
-   ~ Created file at apps/todos_two/resources/main_page.js
-   ~ Created file at apps/todos_two/statechart.js
-   ~ Created directory at apps/todos_two/states
-   ~ Created file at apps/todos_two/states/ready_state.js
-   ~ Created file at apps/todos_two/theme.js
-
-  Your application target is now ready to use!
-```
-
-The directory structure is:
-
-* **getting_started/**
-  * **Buildfile**
-  * **README.md**
-  * **apps/**
-    * **todos_one/**
-      * **...**
-    * **todos_two/**
-      * **Buildfile**
-      * **core.js**
-      * **main.js**
-      * **_statechart.js_**
-      * **theme.js**
-      * **resources/**
-        * **_theme.css**
-        * **loading.rhtml**
-        * **main_page.js**
-      * **_states/_**
-        * **_ready_state.js_**
-
-This structure looks almost identical to the standard app made with the **sproutcore gen app** command, except 
-that you now see two new files, a _statechart.js_ file in the application root directory, and a new 
-_states_ directory with one state file, _ready_state.js_:
+SproutCore generates statechart-based applications by default.
+The basis of the statechart is formed by the _statechart.js_ file in the application root directory, and in the
+_states_ directory _ready_state.js_:
 
 * _statechart.js_, and
 * _states/ready_state.js_
@@ -152,22 +107,22 @@ The _statechart.js_ file describes your statechart and the initial state that sh
 statechart is first initialized. Open it, and you should see the following:
 
 ```javascript
-# filename=apps/todos_two/statechart.js
-TodosTwo.statechart = SC.Statechart.create({
+# filename=apps/TodosOne/statechart.js
+TodosOne.statechart = SC.Statechart.create({
 
   initialState: 'readyState',
 
-  readyState: SC.State.plugin('TodosTwo.ReadyState'),
-  // someOtherState: SC.State.plugin('TodosTwo.SomeOtherState')
+  readyState: SC.State.plugin('TodosOne.ReadyState'),
+  // someOtherState: SC.State.plugin('TodosOne.SomeOtherState')
 
 });
 ```
 
 NOTE: This example uses CamelCase state names.
 
-Note the use of SC.Statechart.create(), instead of SC.Statechart.extend().  Views and models generally 
+Note the use of SC.Statechart.create(), instead of SC.Statechart.extend().  Views and models generally
 use .extend() when you are defining them, because elsewhere in the system, instantiation of objects happens.
-Controllers and the statechart use .create() because we need to directly create objects to work with. 
+Controllers and the statechart use .create() because we need to directly create objects to work with.
 
 Also note the use of the SC.State.plugin() function. This allows you to put your states in separate files in a
 states directory.
@@ -175,30 +130,30 @@ states directory.
 Open _states/ready_state.js_ and take a look:
 
 ```javascript
-# filename=apps/todos_two/states/ready_state.js
-TodosTwo.ReadyState = SC.State.extend({ 
+# filename=apps/TodosOne/states/ready_state.js
+TodosOne.ReadyState = SC.State.extend({
 
   enterState: function() {
-    TodosTwo.getPath('mainPage.mainPane').append();
+    TodosOne.getPath('mainPage.mainPane').append();
   },
- 
+
   exitState: function() {
-    TodosTwo.getPath('mainPage.mainPane').remove();
+    TodosOne.getPath('mainPage.mainPane').remove();
   }
 
 });
 ```
 
-States may define an _enterState()_ function to prepare for the new state, and an _exitState()_ function to 
-clean up after themselves. For user interface programming, these functions are where you show and hide 
+States may define an _enterState()_ function to prepare for the new state, and an _exitState()_ function to
+clean up after themselves. For user interface programming, these functions are where you show and hide
 panels, as you see here, with the use of .append() to show and .remove() to hide.
 
-The TodosTwo.ReadyState is the only state in this "Hello World" app, so it only appends the main
-page's main pane. 
+The TodosOne.ReadyState is the only state in this "Hello World" app, so it only appends the main
+page's main pane.
 
 ### Where Views Fit In
 
-We've covered statecharts, so you know a little bit about how they work. Let's talk about how statecharts 
+We've covered statecharts, so you know a little bit about how they work. Let's talk about how statecharts
 can help organize views and make your code super-clean.
 
 The _resources/main_page.js_ file defines the main user interface of your application.
@@ -208,23 +163,23 @@ childViews array of view references, which uses the 'space delimited strings'.w(
 to make an array:
 
 ```javascript
-# filename=apps/todos_two/resources/main_page.js
-TodosTwo.mainPage = SC.Page.design({
-  
+# filename=apps/TodosOne/resources/main_page.js
+TodosOne.mainPage = SC.Page.design({
+
   mainPane: SC.MainPane.design({
     childViews: 'labelView labelView2'.w(),
-    
+
     labelView: SC.LabelView.design({
       layout: { centerX: 0, centerY: 0, width: 200, height: 18 },
       textAlign: SC.ALIGN_CENTER,
-      tagName: "h1", 
+      tagName: "h1",
       value: "Welcome to SproutCore!"
     }),
-    
+
     labelView2: SC.LabelView.design({
       layout: { centerX: 0, centerY: 15, width: 200, height: 18 },
       textAlign: SC.ALIGN_CENTER,
-      tagName: "h1", 
+      tagName: "h1",
       value: "Now we're rolling!"
     })
   })
@@ -234,41 +189,41 @@ TodosTwo.mainPage = SC.Page.design({
 
 INFO Throughout the Getting Started guides we have minimized in-code comments for brevity.
 
-Note the use of the _.design()_ method here. _.design()_ is often confused with _.extend()_. 
-This confusion is caused by a SproutCore "wart." _.design()_ exists so that views will work 
-with a graphical designer tool for SproutCore (like Interface Builder for Mac OS X) that has 
-been in development for a long time, but remains unfinished, with development long ago stalled. 
-A designer tool might be created in the future, but regardless, there is a logic you can follow, 
-wherein you use _.design()_ when you are **using** a view, and _.extend()_ where you 
-are **defining** it. Here we are using _.design()_, but rest assured that SC.LabelView uses 
-extend where it is defined in the SproutCore codebase. 
+Note the use of the _.design()_ method here. _.design()_ is often confused with _.extend()_.
+This confusion is caused by a SproutCore "wart." _.design()_ exists so that views will work
+with a graphical designer tool for SproutCore (like Interface Builder for Mac OS X) that has
+been in development for a long time, but remains unfinished, with development long ago stalled.
+A designer tool might be created in the future, but regardless, there is a logic you can follow,
+wherein you use _.design()_ when you are **using** a view, and _.extend()_ where you
+are **defining** it. Here we are using _.design()_, but rest assured that SC.LabelView uses
+extend where it is defined in the SproutCore codebase.
 
-NOTE: When you make your own views, remember to use _.extend()_ when you are making the view 
+NOTE: When you make your own views, remember to use _.extend()_ when you are making the view
 in the first place, and _.design()_ elsewhere, where you use it.
 
-If you load up http://localhost:4020/todos_two/ in your browser, you should see both labels now; the second one right below the first.
+If you load up http://localhost:4020/TodosOne/ in your browser, you should see both labels now; the second one right below the first.
 
 #### Separating Views
 
-Before we get into using views with statecharts, let's first arrange view files for TodosTwo. 
-Technically, you can put all view code in <em>main_page.js</em>, but that will get impractical 
+Before we get into using views with statecharts, let's first arrange view files for TodosOne.
+Technically, you can put all view code in <em>main_page.js</em>, but that will get impractical
 very fast. Instead you can separate each view into it's own file. This is accomplished by
 using the special _sc_require()_ functionality. Modify the mainPane of the mainPage view to
 have two sc_require() statements at the top, to declare two views as dependencies, and to change
 the childViews of the pane to use these views:
 
 ```javascript
-# filename=apps/todos_two/resources/main_page.js
+# filename=apps/TodosOne/resources/main_page.js
 sc_require('views/welcome');
 sc_require('views/rolling');
 
-TodosTwo.mainPage = SC.Page.design({
+TodosOne.mainPage = SC.Page.design({
 
   mainPane: SC.MainPane.design({
     childViews: 'welcomeView rollingView'.w(),
-    
-    welcomeView: TodosTwo.WelcomeView.design(),
-    rollingView: TodosTwo.RollingView.design()
+
+    welcomeView: TodosOne.WelcomeView.design(),
+    rollingView: TodosOne.RollingView.design()
   })
 
 });
@@ -277,39 +232,33 @@ TodosTwo.mainPage = SC.Page.design({
 _sc_require()_ functionality:
 
 1. The file path used in _sc_require()_ is relative to the application's root directory.
-2. The reference in _sc_require()_ has the filename sans the .js extension.
-3. The load order for javascript files will be alphabetical, unless otherwise controlled with sc_require().  Sometimes you 
-get lucky on the default file loading order, if you omit a sc_require() statement. Sometimes you don't, and 
+2. The reference in _sc_require()_ has the filename without the .js extension.
+3. The load order for javascript files will be alphabetical, unless otherwise controlled with sc_require().  Sometimes you
+get lucky on the default file loading order, if you omit a sc_require() statement. Sometimes you don't, and
 you will get a dependency error.
 
 
 
-Now create the views folder for our new WelcomeView and RollingView:
-
-```bash
-$ cd ~/development/sproutcore/getting_started
-$ mkdir apps/todos_two/views
-```
-
-Next, add the views. Make sure the files have the following content and are located in the views
+Now create the view files for our new WelcomeView and RollingView.
+Make sure the files have the following content and are located in the views
 directory:
 
 ```javascript
-# filename=apps/todos_two/views/welcome.js
-TodosTwo.WelcomeView = SC.LabelView.extend({
+# filename=apps/TodosOne/views/welcome.js
+TodosOne.WelcomeView = SC.LabelView.extend({
   layout: { centerX: 0, centerY: 0, width: 200, height: 18 },
   textAlign: SC.ALIGN_CENTER,
-  tagName: "h1", 
+  tagName: "h1",
   value: "Welcome to SproutCore!"
 });
 ```
 
 ```javascript
-# filename=apps/todos_two/views/rolling.js
-TodosTwo.RollingView = SC.LabelView.extend({
+# filename=apps/TodosOne/views/rolling.js
+TodosOne.RollingView = SC.LabelView.extend({
   layout: { centerX: 0, centerY: 15, width: 200, height: 18 },
   textAlign: SC.ALIGN_CENTER,
-  tagName: "h1", 
+  tagName: "h1",
   value: "Now we're rolling!"
 });
 ```
@@ -319,65 +268,65 @@ but now your code is cleaner and more manageable.
 
 #### Handling Events and Statechart Actions
 
-Standard events for a web application include the ubiquitous mouseDown, and many others. Here we add 
-an event to watch for mouseDown in our TodosTwo.RollingView, associating it with a statechart action:
+Standard events for a web application include the ubiquitous mouseDown, and many others. Here we add
+an event to watch for mouseDown in our TodosOne.RollingView, associating it with a statechart action:
 
 ```javascript
-# filename=apps/todos_two/views/rolling.js
-TodosTwo.RollingView = SC.LabelView.design({
+# filename=apps/TodosOne/views/rolling.js
+TodosOne.RollingView = SC.LabelView.design({
   layout: { centerX: 0, centerY: 15, width: 200, height: 18 },
   textAlign: SC.ALIGN_CENTER,
-  tagName: "h1", 
+  tagName: "h1",
   value: "Now we're rolling!",
-  
+
   mouseDown: function(evt) {
     var someParam = "Woot!";
 
-    TodosTwo.statechart.sendAction('proveIt', someParam);
+    TodosOne.statechart.sendAction('proveIt', someParam);
   }
 });
 ```
 
-We set a _proveIt_ action to happen on the mouseDown event, using the statechart.sendAction() function. We must 
+We set a _proveIt_ action to happen on the mouseDown event, using the statechart.sendAction() function. We must
 handle the action in the appropriate state in the statechart.
 
-The statechart has a property for the _current state_. When the statechart recieves an 
-action event, it will first ask the current state to handle it. If the current state cannot handle 
-it, the statechart will ask the current state's parent state to handle the event. Attempts 
-continue in this manner, bubbling up until either an ancestor state is found that can handle 
-the event, or it will log a warning for the developer.  You can see warnings, as well as other 
+The statechart has a property for the _current state_. When the statechart recieves an
+action event, it will first ask the current state to handle it. If the current state cannot handle
+it, the statechart will ask the current state's parent state to handle the event. Attempts
+continue in this manner, bubbling up until either an ancestor state is found that can handle
+the event, or it will log a warning for the developer.  You can see warnings, as well as other
 informational messages (such as for state transitions), by turning on tracing on the statechart.
 
 Do that now:
 
 ```javascript
-# filename=apps/todos_two/statechart.js
-TodosTwo.statechart = SC.Statechart.create({
-    
+# filename=apps/TodosOne/statechart.js
+TodosOne.statechart = SC.Statechart.create({
+
   trace: YES,   // <-- Add this line
-    
+
   initialState: 'readyState',
-    
-  readyState: SC.State.plugin('TodosTwo.ReadyState')
-  
+
+  readyState: SC.State.plugin('TodosOne.ReadyState')
+
 });
 ```
 
-Let's make our TodosTwo.ReadyState handle the _proveIt_ action that was defined on
-the mouseDown event in TodosTwo.RollingView above:
+Let's make our TodosOne.ReadyState handle the _proveIt_ action that was defined on
+the mouseDown event in TodosOne.RollingView above:
 
 ```javascript
-# filename=apps/todos_two/states/ready_state.js
-TodosTwo.ReadyState = SC.State.extend({
-  
+# filename=apps/TodosOne/states/ready_state.js
+TodosOne.ReadyState = SC.State.extend({
+
   enterState: function() {
-    TodosTwo.getPath('mainPage.mainPane').append();
+    TodosOne.getPath('mainPage.mainPane').append();
   },
-    
+
   exitState: function() {
-    TodosTwo.getPath('mainPage.mainPane').remove();
+    TodosOne.getPath('mainPage.mainPane').remove();
   },
-  
+
   // Prove that we are rolling!
   proveIt: function(someParam) {
     alert(someParam);
@@ -390,7 +339,7 @@ proveIt() is a function. It is an action in the ReadyState state.
 
 Save your files and refresh the page. When you click on the "Now we're rolling!"
 label, you should see an alert. If you look at the console output, you can also
-see the tracing reports, with the event being handled by the statechart, as well 
+see the tracing reports, with the event being handled by the statechart, as well
 as the initialization and the transition to the readyState.
 
 ### Moving Forward
@@ -398,8 +347,8 @@ as the initialization and the transition to the readyState.
 You are now ready to move on to creating a full-scale SproutCore app!
 
 [Part 3](/getting_started_3.html) will introduce you to a more complete Todos application,
-called TodosThree, and walk you through the process of building it from scratch. 
-You will learn about models, controllers and how they tie in with the statechart 
+called TodosTwo, and walk you through the process of building it from scratch.
+You will learn about models, controllers and how they tie in with the statechart
 and views.
 
 Dive in to [Getting Started: Part 3](/getting_started_3.html).
@@ -411,5 +360,6 @@ Dive in to [Getting Started: Part 3](/getting_started_3.html).
 * March 6, 2012: rewrite for SproutCore 1.8 by the 1.8 release sprint team, including the following who
   did much work on this task: [Tim Evans](credits.html#tce), [Topher Fangio](credits.html#topherfangio),
   [Jeff Pittman](credits.html#geojeff)
-* July 30, 2013: converted to Markdown format for DocPad guides by [Eric Theise](credits.html#erictheise) 
+* July 30, 2013: converted to Markdown format for DocPad guides by [Eric Theise](credits.html#erictheise)
 * July 30, 2013: fix issues with formatting and updated Changelog by [Topher Fangio](credits.html#topherfangio)
+* Jan 17, 2019: Update the guide as the default application already uses the state chart.

--- a/src/documents/getting_started_3.html.md.sd
+++ b/src/documents/getting_started_3.html.md.sd
@@ -9,30 +9,30 @@ sc_list:
   - Generate a new statechart-based application called TodosThree.
   - Edit files created by the generation boilerplate system.
   - Add a models directory, containing the Todo model definition.
-  - Add a controllers directory, containing two controllers.
-  - Add a fixtures directory, containing a file with JSON-formatted sample data.
+  - Add two controllers.
+  - Add a fixtures file with JSON-formatted sample data.
   - Celebrate powerful SproutCore programming constructs, learned along the way.
 ---
 
 
 ### Following Along
 
-You have learned in previous guides how to use **sproutcore gen** to make a project directory and to create apps
-in the project apps directory. You have learned how to run **sproutcore server** in the project directory, and
+You have learned in previous guides how to use **sproutcore init** to make a project directory and to create apps
+in the project apps directory. You have learned how to run **sproutcore serve** in the project directory, and
 how to view apps in a local browser at localhost:4020/. You have learned about SproutCore app concepts,
 including knowledge of views and statecharts. We will build on that foundation to produce a
 TodosThree app with components of a best-practices SproutCore app.
 
 You would benefit from carefully following the instructions in this guide to create directories, to type in
 code (or to copy and paste it), because it will register in your mind solidly. The presentation is written as
-if you would add the app in this manual fashion, although you surely might prefer instead to get the finished 
+if you would add the app in this manual fashion, although you surely might prefer instead to get the finished
 source code and read along as if you had done it manually:
 
 You may wish to clone with **git clone git://github.com/sproutcore/getting-started.git getting_started** from [Github](https://github.com/sproutcore/getting-started) into your work area.
 
 INFO Reminder: These "Getting Started" guides attempt to strike a matter-of-fact tone that doesn't sugar-coat
-complexity too much, but tries not to overwhelm. We are ramping up to inherently more challenging concepts, however. 
-If you need help, please ask questions in IRC or on the mailing list, with references to the numeric heading 
+complexity too much, but tries not to overwhelm. We are ramping up to inherently more challenging concepts, however.
+If you need help, please ask questions in IRC or on the mailing list, with references to the numeric heading
 for relevant sections of this guide page.
 
 ### Creating A TodosThree Application
@@ -41,16 +41,14 @@ Here is a screen capture of the completed application:
 
 <div><img src="images/getting_started/todos_three_screen_capture.png"></div>
 
-Or view [TodosThree in action](http://sproutcore.com/getting-started/).
-
 The TodosThree app looks simple. It has toolbars at the top and bottom. It has a text field near the top,
 where a user types in a new todo. It has a list of already added todos. Even such a simple-looking app like
 this involves the use of intelligent SproutCore programming.
 
 We can describe these intelligent aspects, generally, as the "system of connections" or, in the manner an
-electrician would use, as the "wiring diagram." SproutCore apps have _bindings_ and _observers_ between various 
-components of the user interface and those of underlying machinery, the normal complement of events in a web app, 
-and _actions_ coordinated with _states_. 
+electrician would use, as the "wiring diagram." SproutCore apps have _bindings_ and _observers_ between various
+components of the user interface and those of underlying machinery, the normal complement of events in a web app,
+and _actions_ coordinated with _states_.
 
 You see the components of the user interface in the screen capture: checkboxes, buttons, text fields, list
 views, etc. We'll be looking at the underlying machinery.
@@ -58,11 +56,11 @@ views, etc. We'll be looking at the underlying machinery.
 This will be the directory structure for the TodosThree app:
 
 * **getting_started/** - The project directory, for holding several apps.
-  * **Buildfile**
+  * **sc_config**
   * **README.md**
   * **apps/**
-    * **todos_three/**
-      * **Buildfile**
+    * **TodosThree/**
+      * **sc_config**
       * **core.js**
       * **main.js**
       * **theme.js**
@@ -73,7 +71,7 @@ This will be the directory structure for the TodosThree app:
         * **showing_app.js**
         * **showing_destroy_confirmation**
       * **resources/**
-        * **loading.rhtml**
+        * **loading.ejs**
         * **main_page.js**
         * **todo_item.js**
         * **_theme.css**
@@ -89,11 +87,11 @@ This will be the directory structure for the TodosThree app:
 Here is that directory structure again, with descriptions for each item:
 
 * **getting_started/** - The project directory, for holding several apps.
-  * **Buildfile** | _Configuration for the project_
+  * **sc_config** | _Configuration for the project_
   * **README.md** | _Describes your app and how to use it_
   * **apps/**
-    * **todos_three/**
-      * **Buildfile** | _Configuration for the TodosThree app_
+    * **TodosThree/**
+      * **sc_config** | _Configuration for the TodosThree app_
       * **core.js** | _TodosThree app creation code_
       * **main.js** | _Adds a data store, and calls the TodosThree.mainPage view_
       * **theme.js** | _Adds a TodosThree.Theme based on the SproutCore Ace theme_
@@ -104,7 +102,7 @@ Here is that directory structure again, with descriptions for each item:
         * **showing_app.js** | _The SHOWING_APP state, the general state for responding to user actions_
         * **showing_destroy_confirmation** | _The SHOWING_DESTROY_CONFIRMATION state_
       * **resources/**
-        * **loading.rhtml** | _A short html file to show when the app is loading_
+        * **loading.ejs** | _A short html file to show when the app is loading_
         * **main_page.js** | _The TodosThree.mainPage view_
         * **todo_item.js** | _TodoItem code for a checkbox and a title_
         * **_theme.css** | _Contains per directory theme setup_
@@ -126,39 +124,23 @@ TodosThree app (You should be in the ~/development/sproutcore/getting_started pr
 
 ```bash
 $ cd ~/development/sproutcore/getting_started
-
-  sproutcore gen statechart_app TodosThree
-
- ~ Created directory at apps
- ~ Created directory at apps/todos_three
- ~ Created file at apps/todos_three/Buildfile
- ~ Created file at apps/todos_three/core.js
- ~ Created file at apps/todos_three/main.js
- ~ Created directory at apps/todos_three/resources
- ~ Created file at apps/todos_three/resources/_theme.css
- ~ Created file at apps/todos_three/resources/loading.rhtml
- ~ Created file at apps/todos_three/resources/main_page.js
- ~ Created file at apps/todos_three/statechart.js
- ~ Created directory at apps/todos_three/states
- ~ Created file at apps/todos_three/states/ready_state.js
- ~ Created file at apps/todos_three/theme.js
-
-Your application target is now ready to use!
+$ sproutcore gen app TodosThree
+Your project has been successfully created!
 
 ```
 
-NOTE: **GIT**: git add apps/todos_three & git commit -a -m 'Added todos_three app with _sproutcore gen statechart_app TodosThree_ command.'
+NOTE: **GIT**: git add apps/TodosThree & git commit -a -m 'Added TodosThree app with _sproutcore gen app TodosThree_ command.'
 
 INFO Where you see such GIT notes in this guide, you can ignore them. If you know what they mean, you may use these
 cues to commit to your own repo as you go. They are really for internal use in generating the associated repo.
 
 We will work through the app, directory by directory, file by file, to edit those files and to add other
-needed directories and files. 
+needed directories and files.
 
 #### The App Root Directory
 
 There are four .js files in the TodosThree app root directory
-(~/development/sproutcore/getting_started/apps/todos_three/):
+(~/development/sproutcore/getting_started/apps/TodosThree/):
 
 | theme.js | core.js |. main.js | statechart.js |
 
@@ -167,8 +149,8 @@ Edit these files to assure their content matches that given in the following sec
 ##### theme.js (app root directory)
 
 ```javascript
-# filename=apps/todos_three/theme.js
-TodosThree.Theme = SC.AceTheme.create({
+# filename=apps/TodosThree/theme.js
+TodosThree.Theme = SC.AkiTheme.create({
   name: 'todos-three'
 });
 
@@ -184,13 +166,13 @@ and a default 'todos-three' namespace is created.
 ##### core.js (app root directory)
 
 ```javascript
-# filename=apps/todos_three/core.js
+# filename=apps/TodosThree/core.js
 TodosThree = SC.Application.create(
   /** @scope TodosThree.prototype */ {
- 
+
   NAMESPACE: 'TodosThree',
   VERSION: '0.1.0',
- 
+
   store: SC.Store.create().from(SC.FixturesDataSource.create({
     simulateRemoteResponse: YES,
     latency: 250
@@ -210,11 +192,11 @@ to have time to operate as it would in a normal web app situation.
 ##### main.js (app root directory)
 
 ```javascript
-# filename=apps/todos_three/main.js
+# filename=apps/TodosThree/main.js
 TodosThree.main = function () {
   TodosThree.statechart.initStatechart();
 };
- 
+
 function main() { TodosThree.main(); }
 ```
 
@@ -224,16 +206,16 @@ handle the complexity.
 ##### statechart.js (app root directory)
 
 ```javascript
-# filename=apps/todos_three/statechart.js
+# filename=apps/TodosThree/statechart.js
 TodosThree.statechart = SC.Statechart.create({
 
   trace: YES,
- 
+
   rootState: SC.State.design({
     initialSubstate: "READY",
- 
+
     READY: SC.State.plugin('TodosThree.READY'),
-      
+
     LOGGING_IN: SC.State.plugin('TodosThree.LOGGING_IN'),
 
     SHOWING_APP: SC.State.plugin('TodosThree.SHOWING_APP'),
@@ -243,6 +225,21 @@ TodosThree.statechart = SC.Statechart.create({
 
 });
 ```
+
+Also edit the sc_config file to match the following:
+
+```javascript
+var TodosThree = BT.AppBuilder.create({
+  name: 'TodosThree',
+  theme: 'sproutcore:aki',
+  path: dirname(),
+  title: 'TodosThree',
+  frameworks: [],
+  languages: ['en']
+});
+```
+
+Make sure to restart the development server whenever you change the sc_config file.
 
 NOTE: **GIT**: git commit -a -m 'Edited files in the root app directory.'
 
@@ -258,36 +255,37 @@ SHOWING_DESTROY_CONFIRMATION. These are defined in individual files in the state
 Code for individual states is held in the states directory. Change to that directory:
 
 ```bash
-$ cd ~/development/sproutcore/getting_started/apps/todos_three/states
-``` 
+$ cd ~/development/sproutcore/getting_started/apps/TodosThree/states
+```
 
 *sproutcore gen* created a file called ready_state.js in the states directory. We are going to use it for the
 TodosThree app, but to make it match our file naming pattern, rename it to ready.js:
 
 ```bash
 $ mv ready_state.js ready.js
-``` 
+```
 
-Files to edit or add in the apps/todos_three/states directory are:
+Files to edit or add in the apps/TodosThree/states directory are:
 
 | ready.js | logging_in.js | showing_app.js | showing_destroy_confirmation.js |
 
 ##### READY State (replace content of renamed ready.js)
 
 ```javascript
-# filename=apps/todos_three/states/ready.js
+# filename=apps/TodosThree/states/ready.js
 TodosThree.READY = SC.State.design({
+
   enterState: function() {
     if (SC.instanceOf(TodosThree.store.dataSource, SC.FixturesDataSource)) {
       TodosThree.todosController.set('content',
         TodosThree.store.find(SC.Query.local(TodosThree.Todo, { orderBy: 'timestamp DESC' })));
       TodosThree.completedTodosController.set('content',
-        TodosThree.store.find(SC.Query.local(TodosThree.Todo, 'isCompleted = true')));
+        TodosThree.store.find(SC.Query.local(TodosThree.Todo, { conditions: 'isCompleted = true' })));
     } else {
       this.gotoState('LOGGING_IN');
     }
   },
- 
+
   didLoad: function () {
     if (TodosThree.todosController.get('status') === SC.Record.READY_CLEAN) {
       this.gotoState('SHOWING_APP');
@@ -317,14 +315,14 @@ _If the status of the content changes, fire this function._
 When the didLoad function is fired, there is an explicit check to see that the status change was to become
 SC.READY_CLEAN, and if so, to move control to the SHOWING_APP state.
 
-This is a common pattern in SproutCore apps: Use bindings, described in a section below, whenever you can to 
-solve most problems, but there are also cases to use an observer function to wait for some task to complete 
-before firing. Try not to abuse observers, however, because in certain situations, there are performance 
-penalties. This is especially true where you do not follow best practices for wiring things together, and there 
+This is a common pattern in SproutCore apps: Use bindings, described in a section below, whenever you can to
+solve most problems, but there are also cases to use an observer function to wait for some task to complete
+before firing. Try not to abuse observers, however, because in certain situations, there are performance
+penalties. This is especially true where you do not follow best practices for wiring things together, and there
 is inefficient, or even unneeded updating.
 
 Here we are creating an observer in a state, so we use the dedicated .stateObserves() observer style,
-but in general use, the observer function, used in exactly the same way, is simply called .observes(). 
+but in general use, the observer function, used in exactly the same way, is simply called .observes().
 There are nuances to learn about specifying paths in observer declarations, such as how to use absolute (a.b.c)
 vs. relative paths (.b.c), and how to use chained absolute (a*b.c) vs. chained relative (*b.c) paths. We will
 leave the details for other documentation, where a full coverage can be given to how each use specifies a different
@@ -332,15 +330,15 @@ set of triggers for an observer update.
 
 ###### *Initialization of the Controllers*
 
-Controllers are part of the communications system, often used specifically as interfaces to data models, in concert 
+Controllers are part of the communications system, often used specifically as interfaces to data models, in concert
 with the statechart, which covers more general purpose connections. Controllers needn't contain a large amount of
 code to play a key role, and often don't. We distinguish between array and object controllers; in TodosThree, we
 only use SC.ArrayController.
 
 Data content of the two array controllers used in TodosThree is set in enterState() by issuing data query find
-calls to the store. SC.Query.local() is used because we know we don't have to find the data remotely in the 
-TodosThree app. We search for todos, referencing the TodosThree.Todo model (an SC.Record instance). For the 
-primary controller, todosController, we search for all the todos, ordering them by their timestamp property. 
+calls to the store. SC.Query.local() is used because we know we don't have to find the data remotely in the
+TodosThree app. We search for todos, referencing the TodosThree.Todo model (an SC.Record instance). For the
+primary controller, todosController, we search for all the todos, ordering them by their timestamp property.
 For the completedTodosController, we search for all the todos for which isCompleted is true.
 
 These aren't "one-time searches." They are associations set between the 'content' property of a
@@ -352,18 +350,18 @@ NOTE: **GIT**: git commit -a -m 'Renamed ready_state.js file to ready.js. Edited
 ##### LOGGING_IN State
 
 ```javascript
-# filename=apps/todos_three/states/logging_in.js
-TodosThree.LOGGING_IN = SC.State.design({             
+# filename=apps/TodosThree/states/logging_in.js
+TodosThree.LOGGING_IN = SC.State.design({
   initialSubstate: "SHOWING_LOGIN",
- 
+
   SHOWING_LOGIN: SC.State.design({
- 
+
     enterState: function() {
     },
- 
+
     exitState: function() {
     },
- 
+
     authenticate: function() {
     }
   })
@@ -375,7 +373,7 @@ INFO We won't use the LOGGING_IN state in TodosThree, but have it here for illus
 ##### SHOWING_APP State
 
 ```javascript
-# filename=apps/todos_three/states/showing_app.js
+# filename=apps/TodosThree/states/showing_app.js
 TodosThree.SHOWING_APP = SC.State.design({
   enterState: function() {
     TodosThree.mainPage.get('mainPane').append();
@@ -411,7 +409,7 @@ which we will see in the mainPage view in the resources directory.
 ##### SHOWING_DESTROY_CONFIRMATION State
 
 ```javascript
-# filename=apps/todos_three/states/showing_destroy_confirmation.js
+# filename=apps/TodosThree/states/showing_destroy_confirmation.js
 TodosThree.SHOWING_DESTROY_CONFIRMATION = SC.State.design({
   _panel: null,
 
@@ -437,7 +435,7 @@ TodosThree.SHOWING_DESTROY_CONFIRMATION = SC.State.design({
       ]
     });
   },
- 
+
   exitState: function() {
     // No need to do anything here, the SC.AlertPane will remove itself.
   },
@@ -454,43 +452,43 @@ TodosThree.SHOWING_DESTROY_CONFIRMATION = SC.State.design({
 ```
 
 When the SHOWING_DESTROY_CONFIRMATION state is entered, the current list of completed todos is grabbed and
-formatted nicely, and then a warning pane is shown to make sure that the user actually wants to 
-delete their completed todos. If so, we tell the completedTodosController to destroy the current completed 
+formatted nicely, and then a warning pane is shown to make sure that the user actually wants to
+delete their completed todos. If so, we tell the completedTodosController to destroy the current completed
 todos. Then, we go back to the SHOWING_APP state so that the user can enter more todos.
 
 The SHOWING_DESTROY_CONFIRMATION state illustrates how states are just objects: you can add local variables
-to them as you would for any other. You learn to think about a state as something built unto its own for 
+to them as you would for any other. You learn to think about a state as something built unto its own for
 some task, fleshed out with needed properties, bindings, workhorse functions and the like.
 
-_panel is a local variable in the state, marked with a beginning underscore to signify that it is not connected 
-to anything external. 
+_panel is a local variable in the state, marked with a beginning underscore to signify that it is not connected
+to anything external.
 
-completedTodos sets up a local property as a reference to the completedTodosController, for ease of use in this 
-case: in the code for displayDescription, you see where the succinct name completedTodos is used. When we tack Binding 
-onto the end of a property declaration, as with xBinding = something, we are creating a property called x, 
+completedTodos sets up a local property as a reference to the completedTodosController, for ease of use in this
+case: in the code for displayDescription, you see where the succinct name completedTodos is used. When we tack Binding
+onto the end of a property declaration, as with xBinding = something, we are creating a property called x,
 which works via a binding (completedTodos is x here).
 
 NOTE: **GIT**: git add . & git commit -a -m 'Added additional states.'
 
 #### The Resources Directory
 
-We've covered the highest-level parts of the app defined in the statechart. Let's add the rest. 
+We've covered the highest-level parts of the app defined in the statechart. Let's add the rest.
 
 The mainPage view, CSS file, a theme file, and an html page live in a directory called resources.  Go to that
 directory:
 
 ```bash
-$ cd ~/development/sproutcore/getting_started/apps/todos_three/resources
-``` 
+$ cd ~/development/sproutcore/getting_started/apps/TodosThree/resources
+```
 
-Files to edit or add in the apps/todos_three/resources directory are:
+Files to edit or add in the apps/TodosThree/resources directory are:
 
-| main_page.js | todo_item.js | _theme.css | styles.css | loading.rhtml |
+| main_page.js | todo_item.js | _theme.css | styles.css | loading.ejs |
 
 ##### main_page.js (resources directory)
 
 ```javascript
-# filename=apps/todos_three/resources/main_page.js
+# filename=apps/TodosThree/resources/main_page.js
 //sc_require('resources/todo_item'); // Not used. See comments below about exampleView.
 
 TodosThree.mainPage = SC.Page.design({
@@ -541,7 +539,7 @@ TodosThree.mainPage = SC.Page.design({
         isDefaultBinding: '.page.field.focused'
       })
     }),
-    
+
     todosList: SC.ScrollView.design({
       layout: { centerX: 0, width: 500, top: 72, bottom: 36 },
       contentView: SC.ListView.design({
@@ -555,7 +553,7 @@ TodosThree.mainPage = SC.Page.design({
         })
       })
     }),
-        
+
     footer: SC.ToolbarView.design({
       layout: { centerX: 0, width: 500, bottom: 0, height: 36 },
 
@@ -576,9 +574,9 @@ TodosThree.mainPage = SC.Page.design({
 There are four parts to the TodosThree mainPage view: a header and footer, and between them are a newTodoField
 and a todosList. A user types a new todo in the newTodoField, and when they click the button, labeled
 'Add', the new todo is added by means of the todosController's addTodo action. The new todo will show up in
-the todosList. How does this happen? We see the use of bindings again. Look at the lines that have Binding in 
-the property names. When you write user interface element code, you "wire up" these connections with such 
-binding instructions. 
+the todosList. How does this happen? We see the use of bindings again. Look at the lines that have Binding in
+the property names. When you write user interface element code, you "wire up" these connections with such
+binding instructions.
 
 ###### *Toolbars in header and footer*
 
@@ -590,16 +588,16 @@ areAllCompleted() will set isCompleted to true for all todos. That makes areAllC
 of function, called a computed property.
 
 As an introduction to computed properties, we start with a basic one in the title view, an SC.LabelView. You
-see two local properties as totalTodosBinding and completedTodosBinding. The computed property is the value, 
+see two local properties as totalTodosBinding and completedTodosBinding. The computed property is the value,
 declared with a normal no-argument function signature, with .property('totalTodo', 'completedTodos').cacheable()
 chained onto the end. The chained part means:
 
 _Base this computed property on the totalTodos and completedTodos properties, and update it if either of them changes,
 and, also, cache the value so unnecessary updates are avoided._
 
-Note again that the way of setting a binding, as with totalTodosBinding, results in the creation of a property 
-that is referred to as just totalTodos. You see this in the two this.get() calls where the completedTodos are 
-subtracted from the totalTodos.  
+Note again that the way of setting a binding, as with totalTodosBinding, results in the creation of a property
+that is referred to as just totalTodos. You see this in the two this.get() calls where the completedTodos are
+subtracted from the totalTodos.
 
 NOTE: Computed properties, so important in SproutCore, are given a fuller description below, and in other guides pages.
 
@@ -616,24 +614,24 @@ properties that are bound to the associated text field. The valueBinding propert
 which is the text the user enters. Note the use of .page in the valueBinding definition. In this
 context, page refers to the page itself, a helpful global available. Note at the top of the file there is a
 declaration of an outlet called field, so we have a handy reference to the business end of this whole view,
-.page.field, which is the newTodoField view's field. References can be cumbersome. Outlets help. 
+.page.field, which is the newTodoField view's field. References can be cumbersome. Outlets help.
 
 The isDefaultBinding property also involves an interesting path. The reference to the focused boolean will
 make the field become inactive if focus goes elsewhere.
 
 NOTE: Property path syntax -- e.g., the leading . in .page.field.focused -- is something you have to look
 up repeatedly until you are comfortable. In the case of the . here, it means that the path is relative to
-here, this scope. 
- 
+here, this scope.
+
 ###### *todosList*
 
 The todosList view follows the SproutCore idiom for wrapping an SC.ListView inside an SC.ScrollView. The
-contentBinding property of the list is set to TodosThree.todosController. 
+contentBinding property of the list is set to TodosThree.todosController.
 
 ##### todo_item.js (resources directory)
 
 ```javascript
-# filename=apps/todos_three/resources/todo_item.js
+# filename=apps/TodosThree/resources/todo_item.js
 TodosThree.TodoItemView = SC.CheckboxView.design({
   classNames: ['todo-item'],
   valueBinding: '.content.isCompleted',
@@ -644,11 +642,11 @@ TodosThree.TodoItemView = SC.CheckboxView.design({
 This file is not used in the app, but is here for illustration of how you could pull in code from an external
 source file. If you look at resources/main_page.js, you will see that the TodosListView has exampleView set
 as "inline" code for the same checkbox view you see in this resouces/todo_item.js file. Instead of defining
-the exampleView there as an "inline" code block, the require that is commented out at the top of 
+the exampleView there as an "inline" code block, the require that is commented out at the top of
 resources/main_page.js could be used, and the exampleView would be set with the usual property definition,
 exampleView: TodosThree.TodoItemView, which would come from the required resources/todo_item.js file.
 
-Whether you declare your exampleView inline or pull it in from an external file depends on its size and 
+Whether you declare your exampleView inline or pull it in from an external file depends on its size and
 complexity. In TodosThree, it is small enough to declare inline. Whatever the case, we can describe what
 this code does. It helps to focus on the context of this code block within the list view, so look again
 at the resources/main_page.js file.
@@ -661,34 +659,34 @@ items for the todos list are todos, which are defined in the TodosThree.Todo mod
 TodoItemView definition refers to a single todo item in the list. .content.isCompleted refers to this property
 of a todo item. Likewise, titleBinding is bound to the title property of a list todo item.
 
-NOTE: It helps to name such views as SomethingItemView, because the Item part indicates the use in a list. 
+NOTE: It helps to name such views as SomethingItemView, because the Item part indicates the use in a list.
 
 ##### _theme.css (resources directory)
 
 ```css
-# filename=apps/todos_three/resources/_theme.css
+# filename=apps/TodosThree/resources/_theme.css
 /*
   This defines the global $theme variable for use inside your CSS.
   The $theme variable holds the CSS class names for your theme.
-  
+
   You can then theme your app by using CSS like this:
 
       $theme.button {
         color: blue;
         @include slices('white-button.png', $left: 3, $right: 3);
       }
-  
+
   Any _theme.css file is prepended to all files inside its directory,
   and any subdirectories that don't define their own _theme.css file.
-  
+
   This allows you to give different directories different values for
   $theme if you wish.
 */
-$theme: '.ace.todos-three';
+$theme: '.aki.todos-three';
 ```
 
 The underscore starting the name of _theme.css is a dead giveaway that it must apply in some special way to
-the theming system. It defines $theme to be our Ace-derived theme, ace.todos-three, a reference used in CSS code.
+the theming system. It defines $theme to be our Aki-derived theme, aki.todos-three, a reference used in CSS code.
 
 NOTE: A _theme.css file is a per directory (and subdirectories) reference definition, allowing hierarchical
 control for using different themes.
@@ -707,27 +705,36 @@ NOTE: CSS is an art unto itself, an important side of doing SproutCore developme
 ###### *styles.css (resources directory)*
 
 ```css
-# filename=apps/todos_three/resources/styles.css
-$theme: '.ace.todos-three';
+# filename=apps/TodosThree/resources/styles.css
+$theme: '.aki.todos-three';
 
-body { 
+body {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizelegibility;
 }
 
 /* Fix for Chrome bug on accelerated panes */
-.sc-pane { 
+.sc-pane {
   -webkit-transform: none;
 }
 
-$theme.sc-text-field-view { 
+$theme.sc-main {
+  background: -moz-linear-gradient(top, #ddd, #bbb);
+  background: -webkit-gradient(linear, 0%, 0%, 0% 100%, from(#ddd), to(#bbb));
+}
+
+$theme.sc-container-view {
+  background: #fff;
+}
+
+$theme.sc-text-field-view {
   font-size: 14px;
   .hint {
     font-size: 14px;
     line-height: 30px;
   }
- 
-  .padding { 
+
+  .padding {
     left: 14px;
   }
 }
@@ -739,13 +746,13 @@ $theme.toolbar {
       top: 50%;
       margin-top: -8px;
     }
- 
-    .label {
+
+    .sc-button-label {
       left: 47px;
       line-height: 36px;
     }
   }
- 
+
   .sc-label-view {
     text-align: right;
     line-height: 36px;
@@ -762,7 +769,7 @@ $theme.todo-item {
     margin-top: -8px;
   }
 
-  .label {
+  .sc-button-label {
     left: 47px;
     line-height: 36px;
   }
@@ -770,28 +777,28 @@ $theme.todo-item {
   &.sel {
     background-color: white;
     color: #AAA;
-    text-decoration: line-through;
+
+    .sc-button-label {
+      text-decoration: line-through;
+    }
   }
 }
 ```
 
-##### loading.rhtml (resources directory)
+##### loading.ejs (resources directory)
 
-SproutCore apps can weigh in north of the welterweight class, so while the app is loading we may need to show
+Because of the complexity SproutCore supports, SproutCore apps can weigh in north of the welterweight class, so while the app is loading we may need to show
 a loading indicator. For TodosThree we don't have to worry, but in larger apps, this file could need some
 attention.
 
 ```html
-# filename=apps/todos_three/resources/loading.rhtml
-<% content_for :loading do %>
-<% # Any HTML in this file will be visible on screen while your page loads
-   # its application JavaScript.  SproutCore applications are optimized for 
-   # caching and startup very fast, so your users will often only see this 
+# filename=apps/TodosThree/resources/loading.ejs
+<!-- # Any HTML in this file will be visible on screen while your page loads
+   # its application JavaScript.  SproutCore applications are optimized for
+   # caching and startup very fast, so your users will often only see this
    # content for a brief moment on their first app load, if at all.
-%>
+-->
 <p class="loading">Loading...<p>
-
-<% end %>
 ```
 
 NOTE: **GIT**: git add . & git commit -a -m 'Edited/Added resources files.'
@@ -803,9 +810,9 @@ NOTE: **GIT**: git add . & git commit -a -m 'Edited/Added resources files.'
 Move to the app root directory, make a models directory, and go there:
 
 ```bash
-$ cd ~/development/sproutcore/getting_started/apps/todos_three
-$ mkdir ~/development/sproutcore/getting_started/apps/todos_three/models
-$ cd ~/development/sproutcore/getting_started/apps/todos_three/models
+$ cd ~/development/sproutcore/getting_started/apps/TodosThree
+$ mkdir ~/development/sproutcore/getting_started/apps/TodosThree/models
+$ cd ~/development/sproutcore/getting_started/apps/TodosThree/models
 ```
 
 NOTE: SproutCore models are based on SC.Record, which offers a substantial set of data definition and
@@ -818,7 +825,7 @@ The models directory will contain one file:
 ##### todo.js (models directory)
 
 ```javascript
-# filename=apps/todos_three/models/todo.js
+# filename=apps/TodosThree/models/todo.js
 sc_require('core');
 
 TodosThree.Todo = SC.Record.extend({
@@ -845,21 +852,19 @@ NOTE: **GIT**: git add . & git commit -a -m 'Added models directory and todo mod
 Move to the TodosThree app root directory, make a controllers directory, and go there:
 
 ```bash
-$ cd ~/development/sproutcore/getting_started/apps/todos_three
-$ mkdir ~/development/sproutcore/getting_started/apps/todos_three/controllers
-$ cd ~/development/sproutcore/getting_started/apps/todos_three/controllers
+$ cd ~/development/sproutcore/getting_started/apps/TodosThree/controllers
 ```
 
 Controllers mediate communications. We'll need a couple in the TodosThree app.
 
-The controllers directory will contain two files: 
+The controllers directory will contain two files:
 
 | todos.js | completed_todos.js |
 
 ##### todos.js (controllers directory)
 
 ```javascript
-# filename=apps/todos_three/controllers/todos.js
+# filename=apps/TodosThree/controllers/todos.js
 sc_require('core');
 
 TodosThree.todosController = SC.ArrayController.create({
@@ -869,7 +874,7 @@ TodosThree.todosController = SC.ArrayController.create({
 ##### completed_todos.js (controllers directory)
 
 ```javascript
-# filename=apps/todos_three/controllers/completed_todos.js
+# filename=apps/TodosThree/controllers/completed_todos.js
 sc_require('controllers/todos');
 
 TodosThree.completedTodosController = SC.ArrayController.create({
@@ -890,7 +895,7 @@ default _content_ reference to the data: you don't see a content property define
 you'll see prevalent use of the content property in most things controller.
 
 The completedTodosController is another array controller. It has a property called totalTodosBinding, and a
-function called areAllCompleted(). 
+function called areAllCompleted().
 
 totalTodosBinding is simple enough. It is a one-way binding (we are "pulling", we don't care about pushing
 back) to the length of the todosController array controller. We need a local reference to this length, because
@@ -902,12 +907,12 @@ areAllCompleted() is a function, but that very special type of function, the com
 in its simpler usage as a "getter." Here we are using a computed property as both a setter and a getter. You see
 the .property() call hanging on the end of the function definition. This gives 'length' and 'totalTodos' as
 dependencies for updating, then tacks on .cacheable(). We have a 'length' property available -- this is a
-built-in property of an array controller. Quiz from something explained earlier: isn't the property called 
+built-in property of an array controller. Quiz from something explained earlier: isn't the property called
 totalTodosBinding not totalTodos? Recall that the answer is that anytime Binding is seen at the end of a property
 name, you have a kind of dual-property arrangement. The "actual" property is, in fact, totalTodos. In defining
-totalTodosBinding, we essentially say to get the value of totalTodos from this other source. 
+totalTodosBinding, we essentially say to get the value of totalTodos from this other source.
 
-That covers the background on mechanics of property names and bindings. As before, here is a human language 
+That covers the background on mechanics of property names and bindings. As before, here is a human language
 explanation of the chained calls on the end (.property('length', 'totalTodos').cacheable()):
 
 _Base this computed property on the length and totalTodos properties, and update it if either of them changes,
@@ -918,56 +923,52 @@ what does the internal code do? k and v are key and value. On a call, if v is a 
 totalTodos value is being changed. This is a mandate to try to mark all todos as completed by this value. The
 name of the computed property is _areAllCompleted_. If a call is made to set it, then the body of the
 function needs to update the data accordingly. If v evaluates to true, then isCompleted for each todo item
-will be set and all the checkboxes will be checked in the list. That explains what the if block does. 
+will be set and all the checkboxes will be checked in the list. That explains what the if block does.
 
 Notice the return on the last line in areAllCompleted(). We return the result of a test comparing the length
 of the array (the local 'length') to the length of the todos array (the local 'totalTodos', which is bound to
 an external source, the full todosController array). If these lengths are the same, then all todos have been
-marked as completed, otherwise no. 
+marked as completed, otherwise no.
 
 NOTE: **GIT**: git add . & git commit -a -m 'Added controllers directory and controller files.'
 
 #### The Fixtures Directory
 
-**sproutcore gen** does not make a fixtures directory. We'll make it.
-
-Move to the TodosThree app root directory, make a fixtures directory, and go there:
+Move to the TodosThree app root directory and go to the fixtures directory:
 
 ```bash
-$ cd ~/development/sproutcore/getting_started/apps/todos_three
-$ mkdir ~/development/sproutcore/getting_started/apps/todos_three/fixtures
-$ cd ~/development/sproutcore/getting_started/apps/todos_three/fixtures
+$ cd ~/development/sproutcore/getting_started/apps/TodosThree/fixtures
 ```
 
-The fixtures directory will contain one file: 
+The fixtures directory will contain one file:
 
 | todo.js |
 
 ##### todo.js (fixtures directory)
 
 ```javascript
-# filename=apps/todos_three/fixtures/todo.js
+# filename=apps/TodosThree/fixtures/todo.js
 sc_require('models/todo');
 
 TodosThree.Todo.FIXTURES = [
  {
    guid: 0,
-   isCompleted: YES,
+   isCompleted: true,
    title: 'Add a SHOWING_APP state'
  },
  {
    guid: 1,
-   isCompleted: YES,
+   isCompleted: true,
    title: 'Edit the buildfile'
  },
  {
    guid: 2,
-   isCompleted: YES,
+   isCompleted: true,
    title: 'Add a TodosThree app'
  },
  {
    guid: 3,
-   isCompleted: YES,
+   isCompleted: true,
    title: 'Install SproutCore'
  }
 ];
@@ -987,17 +988,16 @@ $ cd ~/development/sproutcore/getting_started
 And run it!
 
 ```bash
-$ sproutcore server
+$ sproutcore serve
 ```
 
 Visit http://localhost:4020/ in your favorite modern browser and you should see a list of apps, including
-TodosThree. 
+TodosThree.
 
 ### Where to Go from Here
 
 There are several guides next that treat the build tools, core concepts, several additional pages about
-views, including how to use the alternative system called templates (handlebars), models (records and
-fixtures), theming, and testing.
+views, including how to use models (records and fixtures), theming, and testing.
 
 INFO The guides page called "Core View Concepts" is being updated to mesh better with the Getting Started
 guides.
@@ -1010,7 +1010,7 @@ The following steps are the from Getting Started: Parts 1, 2, and 3, this guide.
 
 cd ~/development/sproutcore
 
-**sproutcore gen project getting_started**
+**sproutcore init getting_started**
 
 cd ~/development/sproutcore/getting_started
 
@@ -1022,79 +1022,75 @@ NOTE: git init & git add Buildfile & git add README & git commit -a -m 'First Co
 
 NOTE: git add apps & git commit -a -m 'Added TodosOne app with _sproutcore gen app TodosOne_ command'
 
-##### Generating TodosTwo
-
-**sproutcore gen statechart_app TodosTwo**
-
-NOTE: git add apps/todos_two & git commit -a -m 'Added TodosTwo app with _sproutcore gen statechart_app TodosTwo_ command'
+##### Inspect the state charts in TodosOne
 
 ##### Generating TodosThree and Doing the Steps Above
 
 **sproutcore gen statechart_app TodosThree**
 
-NOTE: git add apps/todos_three & git commit -a -m 'Added TodosThree app with _sproutcore gen statechart_app TodosThree_ command'
+NOTE: git add apps/TodosThree & git commit -a -m 'Added TodosThree app with _sproutcore gen statechart_app TodosThree_ command'
 
 cd ~/development/sproutcore/getting_started
 
-* **edited file**: apps/todos_three/theme.js
-* **edited file**: apps/todos_three/core.js
-* **edited file**: apps/todos_three/main.js
-* **edited file**: apps/todos_three/statechart.js
+* **edited file**: apps/TodosThree/theme.js
+* **edited file**: apps/TodosThree/core.js
+* **edited file**: apps/TodosThree/main.js
+* **edited file**: apps/TodosThree/statechart.js
 
 NOTE: git commit -a -m 'Edited files in the root app directory.'
 
-cd ~/development/sproutcore/getting_started/apps/todos_three/states
+cd ~/development/sproutcore/getting_started/apps/TodosThree/states
 
 **renamed file: ready_state.js to ready.js**
 
-* **edited file**: apps/todos_three/states/ready.js
+* **edited file**: apps/TodosThree/states/ready.js
 
 NOTE: git commit -a -m 'Renamed ready_state.js file to ready.js. Edited to add controller content setting code.'
 
-* **edited file**: apps/todos_three/states/logging_in.js
-* **edited file**: apps/todos_three/states/showing_app.js
-* **edited file**: apps/todos_three/states/showing_destroy_confirmation.js
+* **edited file**: apps/TodosThree/states/logging_in.js
+* **edited file**: apps/TodosThree/states/showing_app.js
+* **edited file**: apps/TodosThree/states/showing_destroy_confirmation.js
 
 NOTE: git commit -a -m 'Added additional states.'
 
-cd ~/development/sproutcore/getting_started/apps/todos_three/resources
+cd ~/development/sproutcore/getting_started/apps/TodosThree/resources
 
-* **edited file**: apps/todos_three/resources/main_page.js
-* **edited file**: apps/todos_three/resources/todo_item.js
-* **edited file**: apps/todos_three/resources/_theme.css
-* **edited file**: apps/todos_three/resources/styles.css
-* **edited file**: apps/todos_three/resources/loading.rhtml
+* **edited file**: apps/TodosThree/resources/main_page.js
+* **edited file**: apps/TodosThree/resources/todo_item.js
+* **edited file**: apps/TodosThree/resources/_theme.css
+* **edited file**: apps/TodosThree/resources/styles.css
+* **edited file**: apps/TodosThree/resources/loading.ejs
 
 NOTE: git commit -a -m 'Added resources files.'
 
-cd ~/development/sproutcore/getting_started/apps/todos_three
+cd ~/development/sproutcore/getting_started/apps/TodosThree
 
-* **made directory**: ~/development/sproutcore/getting_started/apps/todos_three/models*
+* **made directory**: ~/development/sproutcore/getting_started/apps/TodosThree/models*
 
-cd ~/development/sproutcore/getting_started/apps/todos_three/models
+cd ~/development/sproutcore/getting_started/apps/TodosThree/models
 
-* **edited file**: apps/todos_three/models/todo.js
+* **edited file**: apps/TodosThree/models/todo.js
 
 NOTE: git add models & git commit -a -m 'Added models directory and todo model file.'
 
-cd ~/development/sproutcore/getting_started/apps/todos_three
+cd ~/development/sproutcore/getting_started/apps/TodosThree
 
-* **made directory**: ~/development/sproutcore/getting_started/apps/todos_three/controllers*
+* **made directory**: ~/development/sproutcore/getting_started/apps/TodosThree/controllers*
 
-cd ~/development/sproutcore/getting_started/apps/todos_three/controllers
+cd ~/development/sproutcore/getting_started/apps/TodosThree/controllers
 
-* **edited file**: apps/todos_three/controllers/todos.js
-* **edited file**: apps/todos_three/controllers/completed_todos.js
+* **edited file**: apps/TodosThree/controllers/todos.js
+* **edited file**: apps/TodosThree/controllers/completed_todos.js
 
 NOTE: git add controllers & git commit -a -m 'Added controllers directory and controller files.'
 
-cd ~/development/sproutcore/getting_started/apps/todos_three
+cd ~/development/sproutcore/getting_started/apps/TodosThree
 
-* **made directory**: ~/development/sproutcore/getting_started/apps/todos_three/fixtures*
+* **made directory**: ~/development/sproutcore/getting_started/apps/TodosThree/fixtures*
 
-cd ~/development/sproutcore/getting_started/apps/todos_three/fixtures
+cd ~/development/sproutcore/getting_started/apps/TodosThree/fixtures
 
-* **edited file**: apps/todos_three/fixtures/todo.js
+* **edited file**: apps/TodosThree/fixtures/todo.js
 
 NOTE: git add fixtures & git commit -a -m 'Added fixtures directory and fixture file.'
 
@@ -1111,5 +1107,6 @@ NOTE: git add fixtures & git commit -a -m 'Added fixtures directory and fixture 
 * May 9, 2011: update for recent changes in SproutCore 1.6 by [Tom Dale](credits.html#tomdale) and [Yehuda Katz](credits.html#wycats)
 * March 6, 2012: rewrite for SproutCore 1.8 by the 1.8 release sprint team, including the following who did
   much work on this task: [Tim Evans](credits.html#tce), [Topher Fangio](credits.html#topherfangio), [Jeff Pittman](credits.html#geojeff)
-* July 30, 2013: converted to Markdown format for DocPad guides by [Eric Theise](credits.html#erictheise) 
+* July 30, 2013: converted to Markdown format for DocPad guides by [Eric Theise](credits.html#erictheise)
 * July 30, 2013: fix issues with formatting and updated Changelog by [Topher Fangio](credits.html#topherfangio)
+* January 17, 2019: Update the guide to reflect changes from the NodeJS build tools and CSS names by [Maurits Lamers](credits.html#mauritslamers)

--- a/src/documents/index.html
+++ b/src/documents/index.html
@@ -50,10 +50,6 @@ sc_title: Getting Started
   <h3 class="group">Theming</h3>
 
   <dl>
-      <dt><a href="chance.html">Using Chance, SproutCore's CSS Framework</a></dt>
-      <dd class="clearfix">
-        <p>Chance is SproutCore's CSS preprocessor. In this guide, you will learn how to use the CSS extensions that come with Chance to streamline your styling workflow.</p>
-      </dd>
       <dt><a href="theming_app.html">Theming Your App</a></dt>
       <dd class="clearfix">
         <p>In this guide, we'll cover how to change the style of SproutCore controls in your app. As an example, we'll re-theme an SC.ButtonView.</p>


### PR DESCRIPTION
Describe the NodeJS build tools instead of Abbott, and bring the getting started guides up to date with sproutcore master.